### PR TITLE
Accept personality_dimensions in MindConfig and render in action-selection prompt (NPC-672)

### DIFF
--- a/mind/src/mind/cognitive_architecture/nodes/action_selection/node.py
+++ b/mind/src/mind/cognitive_architecture/nodes/action_selection/node.py
@@ -46,6 +46,14 @@ class ActionSelectionNode(LLMNode):
             else "No specific traits"
         )
 
+        # Format personality dimensions (sorted for deterministic prompts)
+        if state.personality_dimensions:
+            dims_text = ", ".join(
+                f"{name}: {value:.2f}" for name, value in sorted(state.personality_dimensions.items())
+            )
+        else:
+            dims_text = "No personality dimensions provided"
+
         # Build world knowledge from centralized knowledge files
         world_knowledge = KnowledgeBase.get([
             KnowledgeFile.NEEDS,
@@ -60,6 +68,7 @@ class ActionSelectionNode(LLMNode):
                 state,
                 working_memory=str(state.working_memory),
                 personality_traits=personality_text,
+                personality_dimensions=dims_text,
                 available_actions=actions_text,
                 recent_events=pformat(state.recent_events),
                 world_knowledge=world_knowledge,

--- a/mind/src/mind/cognitive_architecture/nodes/action_selection/node.py
+++ b/mind/src/mind/cognitive_architecture/nodes/action_selection/node.py
@@ -48,9 +48,7 @@ class ActionSelectionNode(LLMNode):
 
         # Format personality dimensions (sorted for deterministic prompts)
         if state.personality_dimensions:
-            dims_text = ", ".join(
-                f"{name}: {value:.2f}" for name, value in sorted(state.personality_dimensions.items())
-            )
+            dims_text = "\n".join(f"{name}: {value:.2f}" for name, value in sorted(state.personality_dimensions.items()))
         else:
             dims_text = "No personality dimensions provided"
 

--- a/mind/src/mind/cognitive_architecture/nodes/action_selection/prompt.md
+++ b/mind/src/mind/cognitive_architecture/nodes/action_selection/prompt.md
@@ -14,6 +14,9 @@ You are modeling a person making moment-to-moment decisions in a simulated world
 ### Personality Traits
 {personality_traits}
 
+### Personality Dimensions (0.0 = low, 1.0 = high)
+{personality_dimensions}
+
 ### Recent Events
 {recent_events}
 

--- a/mind/src/mind/cognitive_architecture/state.py
+++ b/mind/src/mind/cognitive_architecture/state.py
@@ -22,6 +22,7 @@ class PipelineState(BaseModel):
     observation: Observation
     available_actions: list[AvailableAction] = Field(default_factory=list)
     personality_traits: list[str] = Field(default_factory=list)
+    personality_dimensions: dict[str, float] = Field(default_factory=dict)
 
     # Working state
     working_memory: WorkingMemory = Field(default_factory=WorkingMemory)

--- a/mind/src/mind/interfaces/mcp/mind.py
+++ b/mind/src/mind/interfaces/mcp/mind.py
@@ -27,6 +27,7 @@ class Mind:
     pipeline: CognitivePipeline
     memory_store: VectorDBMemory
     working_memory: WorkingMemory
+    personality_dimensions: dict[str, float] = field(default_factory=dict)
     daily_memories: list[NewMemory] = field(default_factory=list)
 
     # Conversation history aggregation (keyed by interaction_id)
@@ -73,6 +74,7 @@ class Mind:
             mind_id=mind_id,
             entity_id=config.entity_id,
             traits=config.traits,
+            personality_dimensions=config.personality_dimensions,
             pipeline=pipeline,
             memory_store=memory_store,
             working_memory=working_memory,

--- a/mind/src/mind/interfaces/mcp/models.py
+++ b/mind/src/mind/interfaces/mcp/models.py
@@ -27,6 +27,9 @@ class MindConfig(BaseModel):
     initial_working_memory: WorkingMemory | None = None
     initial_long_term_memories: list[str] = Field(default_factory=list)
 
+    # Personality dimensions (numeric trait dimensions from substrate, 0.0-1.0)
+    personality_dimensions: dict[str, float] = Field(default_factory=dict)
+
 
 # === Protocol: Simulation → Mind ===
 

--- a/mind/src/mind/interfaces/mcp/models.py
+++ b/mind/src/mind/interfaces/mcp/models.py
@@ -1,6 +1,6 @@
 """MCP protocol models - requests, responses, configuration"""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, confloat
 
 from mind.apis.langchain_llm import LangChainModel
 from mind.cognitive_architecture.actions import Action
@@ -28,7 +28,7 @@ class MindConfig(BaseModel):
     initial_long_term_memories: list[str] = Field(default_factory=list)
 
     # Personality dimensions (numeric trait dimensions from substrate, 0.0-1.0)
-    personality_dimensions: dict[str, float] = Field(default_factory=dict)
+    personality_dimensions: dict[str, confloat(ge=0.0, le=1.0)] = Field(default_factory=dict)
 
 
 # === Protocol: Simulation → Mind ===

--- a/mind/src/mind/interfaces/mcp/models.py
+++ b/mind/src/mind/interfaces/mcp/models.py
@@ -1,6 +1,8 @@
 """MCP protocol models - requests, responses, configuration"""
 
-from pydantic import BaseModel, Field, confloat
+from typing import Annotated
+
+from pydantic import BaseModel, Field
 
 from mind.apis.langchain_llm import LangChainModel
 from mind.cognitive_architecture.actions import Action
@@ -28,7 +30,7 @@ class MindConfig(BaseModel):
     initial_long_term_memories: list[str] = Field(default_factory=list)
 
     # Personality dimensions (numeric trait dimensions from substrate, 0.0-1.0)
-    personality_dimensions: dict[str, confloat(ge=0.0, le=1.0)] = Field(default_factory=dict)
+    personality_dimensions: dict[str, Annotated[float, Field(ge=0.0, le=1.0)]] = Field(default_factory=dict)
 
 
 # === Protocol: Simulation → Mind ===

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -218,6 +218,7 @@ class MCPServer:
                     available_actions=obs.get_available_actions(pending_incoming_bids=mind.pending_incoming_bids),
                     working_memory=mind.working_memory,
                     personality_traits=mind.traits,
+                    personality_dimensions=mind.personality_dimensions,
                     conversation_histories=mind.conversation_histories,
                     recent_events=mind.event_buffer,
                     pending_incoming_bids=mind.pending_incoming_bids,

--- a/mind/tests/integration/test_mcp_server.py
+++ b/mind/tests/integration/test_mcp_server.py
@@ -28,6 +28,12 @@ def test_mind_config():
     return MindConfig(
         entity_id="test_npc_001",
         traits=["curious", "brave"],
+        personality_dimensions={
+            "extroversion": 0.7,
+            "curiosity": 0.9,
+            "sensitivity": 0.4,
+            "conscientiousness": 0.6,
+        },
         llm_model="google/gemini-2.0-flash-lite-001",
         embedding_model="all-MiniLM-L6-v2",
         memory_storage_path="./tmp/test_chroma_db",
@@ -99,6 +105,38 @@ async def test_create_mind(mcp_server, test_mind_config):
     assert response["status"] == "created"
     assert response["mind_id"] == "test_mind_001"
     assert "test_mind_001" in mcp_server.minds
+
+
+@pytest.mark.asyncio
+async def test_create_mind_stores_personality_dimensions(mcp_server, test_mind_config):
+    """Personality dimensions in config should round-trip into the stored Mind"""
+    await mcp_server.mcp.call_tool(
+        "create_mind", {"mind_id": "test_mind_dims", "config": test_mind_config.model_dump()}
+    )
+
+    mind = mcp_server.minds["test_mind_dims"]
+    assert mind.personality_dimensions == {
+        "extroversion": 0.7,
+        "curiosity": 0.9,
+        "sensitivity": 0.4,
+        "conscientiousness": 0.6,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_mind_without_personality_dimensions_defaults_to_empty(mcp_server):
+    """Configs that omit personality_dimensions should default to an empty dict"""
+    minimal_config = MindConfig(
+        entity_id="minimal_npc",
+        traits=["plain"],
+    )
+
+    await mcp_server.mcp.call_tool(
+        "create_mind", {"mind_id": "test_mind_minimal", "config": minimal_config.model_dump()}
+    )
+
+    mind = mcp_server.minds["test_mind_minimal"]
+    assert mind.personality_dimensions == {}
 
 
 @pytest.mark.asyncio

--- a/mind/tests/unit/test_action_selection_node.py
+++ b/mind/tests/unit/test_action_selection_node.py
@@ -177,6 +177,10 @@ class TestActionSelectionNode:
         assert "curiosity: 0.20" in rendered
         assert "extroversion: 0.85" in rendered
         assert rendered.index("curiosity: 0.20") < rendered.index("extroversion: 0.85")
+        # Dimensions must render on separate lines (multi-line convention matches
+        # other prompt sections like personality_traits / available_actions)
+        assert "curiosity: 0.20\nextroversion: 0.85" in rendered
+        assert "curiosity: 0.20, extroversion: 0.85" not in rendered
 
     async def test_handles_empty_personality_dimensions(self, node, mock_llm):
         """Empty personality_dimensions should render a sentinel string, not crash"""

--- a/mind/tests/unit/test_action_selection_node.py
+++ b/mind/tests/unit/test_action_selection_node.py
@@ -154,6 +154,51 @@ class TestActionSelectionNode:
         assert result.chosen_action is not None
         assert isinstance(result.chosen_action, Action)
 
+    async def test_renders_personality_dimensions_in_prompt(self, node, mock_llm):
+        """Personality dimensions should be rendered into the LLM prompt with sorted keys"""
+        state = PipelineState(
+            observation=Observation(
+                entity_id="test_npc",
+                current_simulation_time=100,
+                status=StatusObservation(position=(5, 10), movement_locked=False),
+            ),
+            working_memory=WorkingMemory(),
+            personality_traits=["curious"],
+            personality_dimensions={"extroversion": 0.85, "curiosity": 0.2},
+            available_actions=[AvailableAction(name="wait", description="Wait")],
+        )
+
+        await node.process(state)
+
+        # The rendered prompt is passed as a HumanMessage to ainvoke
+        call_args = mock_llm.ainvoke.call_args
+        rendered = call_args[0][0][0].content
+        # Sorted alphabetically: curiosity before extroversion
+        assert "curiosity: 0.20" in rendered
+        assert "extroversion: 0.85" in rendered
+        assert rendered.index("curiosity: 0.20") < rendered.index("extroversion: 0.85")
+
+    async def test_handles_empty_personality_dimensions(self, node, mock_llm):
+        """Empty personality_dimensions should render a sentinel string, not crash"""
+        state = PipelineState(
+            observation=Observation(
+                entity_id="test_npc",
+                current_simulation_time=100,
+                status=StatusObservation(position=(5, 10), movement_locked=False),
+            ),
+            working_memory=WorkingMemory(),
+            personality_traits=["curious"],
+            personality_dimensions={},
+            available_actions=[AvailableAction(name="wait", description="Wait")],
+        )
+
+        result = await node.process(state)
+
+        assert result.chosen_action is not None
+        call_args = mock_llm.ainvoke.call_args
+        rendered = call_args[0][0][0].content
+        assert "No personality dimensions provided" in rendered
+
     async def test_handles_empty_cognitive_context(self, node, mock_llm):
         """Should handle state with no cognitive context"""
         state = PipelineState(

--- a/mind/tests/unit/test_mcp_server.py
+++ b/mind/tests/unit/test_mcp_server.py
@@ -432,3 +432,42 @@ class TestMCPServerErrorHandling:
 
         # Verify bid was NOT removed (only removed when responding)
         assert "bid_test_456" in mind.pending_incoming_bids
+
+
+class TestMindConfigValidation:
+    """Pydantic range validation on MindConfig.personality_dimensions (NPC-672)"""
+
+    def test_rejects_value_above_one(self):
+        from pydantic import ValidationError
+        from mind.interfaces.mcp.models import MindConfig
+        with pytest.raises(ValidationError):
+            MindConfig(
+                entity_id="npc_test",
+                traits=["curious"],
+                personality_dimensions={"extroversion": 1.5},
+            )
+
+    def test_rejects_negative_value(self):
+        from pydantic import ValidationError
+        from mind.interfaces.mcp.models import MindConfig
+        with pytest.raises(ValidationError):
+            MindConfig(
+                entity_id="npc_test",
+                traits=["curious"],
+                personality_dimensions={"curiosity": -0.1},
+            )
+
+    def test_accepts_in_range_values(self):
+        from mind.interfaces.mcp.models import MindConfig
+        config = MindConfig(
+            entity_id="npc_test",
+            traits=["curious"],
+            personality_dimensions={
+                "extroversion": 0.0,
+                "curiosity": 0.5,
+                "sensitivity": 1.0,
+            },
+        )
+        assert config.personality_dimensions["extroversion"] == 0.0
+        assert config.personality_dimensions["curiosity"] == 0.5
+        assert config.personality_dimensions["sensitivity"] == 1.0


### PR DESCRIPTION
## Summary

Adds an optional `personality_dimensions` field to `MindConfig` so the Godot simulation can ship the substrate's four normalized personality dimensions (extroversion, curiosity, sensitivity, conscientiousness, range 0.0-1.0) into the MCP cognitive pipeline. The dims flow:

`MindConfig` -> `Mind` -> `PipelineState` -> action_selection node -> rendered into the prompt as deterministic sorted `name: value` lines.

Backward compatible: `personality_dimensions` defaults to `{}`; existing payloads validate unchanged and empty dims render "No personality dimensions provided".

## Risks and trade-offs

**Design decisions:**

- **Nested dict shape, not flattened.** Wire format keeps `personality_dimensions` as a nested object under `config` rather than flattening keys to `MindConfig` roots. Maps 1:1 with GDScript's `Dictionary[String, float]`, gives clean Pydantic typing, and leaves room for future structured fields (e.g., NPC-673 personality descriptors) without renaming.
- **Raw numeric rendering, sorted.** Prompt format is `name: 0.85` per dim, sorted alphabetically by name. Sorted keys make prompts deterministic, which helps prompt caching and snapshot tests. Raw numerics keep the LLM-facing contract simple; a future NPC will likely overlay qualitative descriptors (NPC-673) as a separate prompt section.
- **Coexists with `traits`.** The existing `traits: list[str]` flows unchanged into a separate prompt section. NPC-674 may redesign trait semantics; this PR doesn't touch them.
- **Sequencing.** This Python PR must land **before** the Godot counterpart (NPC-672 Godot side). The server is fully backward compatible with current Godot payloads (no required field), so there's no flag day.

**What could go wrong:** `LangChain.PromptTemplate` parses `{personality_dimensions}` as a required variable. The node always provides it. Audited existing tests; none bypass `process()` to call `call_llm` directly.

**Recommendation:** Merge before the Godot PR.

## Test plan

- [x] `poetry run pytest` -> 166 passed (run twice, stable).
- [x] `poetry run pytest tests/unit/test_action_selection_node.py tests/integration/test_mcp_server.py -v` -> 20 passed (twice).
- [x] New unit tests: `test_renders_personality_dimensions_in_prompt` (sorted-keys assertion via `mock_llm.ainvoke.call_args`) and `test_handles_empty_personality_dimensions`.
- [x] New integration tests: `test_create_mind_stores_personality_dimensions` (round-trip) and `test_create_mind_without_personality_dimensions_defaults_to_empty`.
- [ ] Cross-repo manual check after Godot PR merges: spawn two MCP-mind NPCs with extreme dims (extroversion 0.05 vs 0.95), enable DEBUG logging, verify rendered prompts differ in the dims section.

Generated with [Claude Code](https://claude.com/claude-code)
