### PR TITLE
Ground MCP interaction validity in observation state, not working memory (NPC-688)

### DIFF
--- a/mind/src/mind/cognitive_architecture/actions/models.py
+++ b/mind/src/mind/cognitive_architecture/actions/models.py
@@ -167,8 +167,15 @@ class Action(BaseModel):
                     )
 
     def _validate_act_in_interaction(self, observation):
-        """Validate ACT_IN_INTERACTION action requires appropriate parameters"""
-        if not observation.status or not observation.status.current_interaction:
+        """Validate ACT_IN_INTERACTION action requires appropriate parameters.
+
+        Grounds validity in the observation's authoritative interaction signals
+        (current_interaction AND activity_state == interacting). A stale
+        working-memory belief that "I'm in a conversation" can no longer pass
+        validation once the observation says the interaction has ended
+        (NPC-688). Missing status defaults to rejected.
+        """
+        if not (observation.status and observation.status.is_interacting()):
             raise ValueError("ACT_IN_INTERACTION requires an active interaction")
 
         interaction_name = observation.status.current_interaction.get('interaction_name', '')

--- a/mind/src/mind/cognitive_architecture/actions/models.py
+++ b/mind/src/mind/cognitive_architecture/actions/models.py
@@ -175,7 +175,7 @@ class Action(BaseModel):
         validation once the observation says the interaction has ended
         (NPC-688). Missing status defaults to rejected.
         """
-        if not (observation.status and observation.status.is_interacting()):
+        if not observation.is_interacting():
             raise ValueError("ACT_IN_INTERACTION requires an active interaction")
 
         interaction_name = observation.status.current_interaction.get('interaction_name', '')

--- a/mind/src/mind/cognitive_architecture/nodes/action_selection/node.py
+++ b/mind/src/mind/cognitive_architecture/nodes/action_selection/node.py
@@ -5,13 +5,17 @@ from pathlib import Path
 from pprint import pformat
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import PromptTemplate
 from pydantic import ValidationError
 
 from mind.cognitive_architecture.actions import Action, ActionType
 from mind.cognitive_architecture.nodes.base import LLMNode
-from mind.cognitive_architecture.nodes.formatting import format_personality
+from mind.cognitive_architecture.nodes.formatting import (
+    format_interaction_status as _format_interaction_status,
+)
+from mind.cognitive_architecture.nodes.formatting import (
+    format_personality,
+)
 from mind.cognitive_architecture.observations import MindEvent, MindEventType
 from mind.cognitive_architecture.state import PipelineState
 from mind.knowledge import KnowledgeBase, KnowledgeFile
@@ -62,6 +66,7 @@ class ActionSelectionNode(LLMNode):
                 personality_traits=personality_text,
                 personality_dimensions=dims_text,
                 available_actions=actions_text,
+                interaction_status=_format_interaction_status(state.observation),
                 recent_events=pformat(state.recent_events),
                 world_knowledge=world_knowledge,
                 format_instructions=self.get_format_instructions()

--- a/mind/src/mind/cognitive_architecture/nodes/action_selection/prompt.md
+++ b/mind/src/mind/cognitive_architecture/nodes/action_selection/prompt.md
@@ -20,6 +20,11 @@ You are modeling a person making moment-to-moment decisions in a simulated world
 ### Recent Events
 {recent_events}
 
+### Authoritative Interaction Status
+{interaction_status}
+
+This status is the ground truth from the simulation. Only choose interaction-participation actions (e.g. act_in_interaction) when it confirms you are currently in an interaction. If it says you are NOT interacting, do not attempt to act in or continue an interaction even if working memory still mentions one.
+
 ## Available Actions
 {available_actions}
 

--- a/mind/src/mind/cognitive_architecture/nodes/cognitive_update/node.py
+++ b/mind/src/mind/cognitive_architecture/nodes/cognitive_update/node.py
@@ -4,11 +4,15 @@ from pathlib import Path
 from pprint import pformat
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import PromptTemplate
 
 from mind.cognitive_architecture.nodes.base import LLMNode
-from mind.cognitive_architecture.nodes.formatting import format_personality
+from mind.cognitive_architecture.nodes.formatting import (
+    format_interaction_status as _format_interaction_status,
+)
+from mind.cognitive_architecture.nodes.formatting import (
+    format_personality,
+)
 from mind.cognitive_architecture.state import PipelineState
 from mind.knowledge import KnowledgeBase, KnowledgeFile
 from mind.logging_config import get_logger
@@ -52,6 +56,11 @@ class CognitiveUpdateNode(LLMNode):
             KnowledgeFile.ACTIVITY,
         ])
 
+        # Ground the "am I interacting?" belief in the fresh observation so a
+        # stale working-memory belief ("I'm in a conversation") gets corrected
+        # this cycle rather than persisting after teardown (NPC-688).
+        interaction_status = _format_interaction_status(state.observation)
+
         # Generate cognitive update
         output = await self.call_llm(
             state,
@@ -60,6 +69,7 @@ class CognitiveUpdateNode(LLMNode):
             personality_dimensions=dims_text,
             retrieved_memories=memories_text,
             observation_text=str(state.observation),
+            interaction_status=interaction_status,
             recent_events=pformat(state.recent_events),
             world_knowledge=world_knowledge,
             format_instructions=self.get_format_instructions()

--- a/mind/src/mind/cognitive_architecture/nodes/cognitive_update/prompt.md
+++ b/mind/src/mind/cognitive_architecture/nodes/cognitive_update/prompt.md
@@ -29,6 +29,11 @@ Given the person's current state, memories, and observation, update their workin
 ### Current Observation
 {observation_text}
 
+### Authoritative Interaction Status
+{interaction_status}
+
+This status is the ground truth from the simulation. If it says you are NOT in an interaction, then any prior belief or plan about being mid-interaction (e.g. "in a conversation") is stale — update the situation assessment, goals, and plan to reflect that the interaction has ended.
+
 Update the working memory with:
 1. **Situation assessment** - Your understanding of what's currently happening
 2. **Active goals** - What they're trying to accomplish right now based on their needs and situation

--- a/mind/src/mind/cognitive_architecture/nodes/formatting.py
+++ b/mind/src/mind/cognitive_architecture/nodes/formatting.py
@@ -45,9 +45,8 @@ def format_interaction_status(observation) -> str:
     Defaults to "NOT currently in any interaction" when status is absent or
     partial — a missing field never reads as "interacting".
     """
-    status = getattr(observation, "status", None)
-    if status is not None and status.is_interacting():
-        interaction_name = status.current_interaction.get("interaction_name", "interaction")
+    if observation is not None and observation.is_interacting():
+        interaction_name = observation.status.current_interaction.get("interaction_name", "interaction")
         return (
             f"You ARE currently in an interaction ({interaction_name}). "
             "Interaction-participation actions are valid."

--- a/mind/src/mind/cognitive_architecture/nodes/formatting.py
+++ b/mind/src/mind/cognitive_architecture/nodes/formatting.py
@@ -31,3 +31,28 @@ def format_personality(
         dims_text = "No personality dimensions provided"
 
     return traits_text, dims_text
+
+
+def format_interaction_status(observation) -> str:
+    """Render the observation's authoritative interaction status for prompts.
+
+    Grounds the LLM's "am I interacting?" belief in the current observation
+    (current_interaction + activity_state), so a stale working-memory belief
+    can be corrected each cycle rather than driving the NPC-688 desync loop.
+    Shared by cognitive_update and action_selection so both nodes see an
+    identical, single-source-of-truth rendering.
+
+    Defaults to "NOT currently in any interaction" when status is absent or
+    partial — a missing field never reads as "interacting".
+    """
+    status = getattr(observation, "status", None)
+    if status is not None and status.is_interacting():
+        interaction_name = status.current_interaction.get("interaction_name", "interaction")
+        return (
+            f"You ARE currently in an interaction ({interaction_name}). "
+            "Interaction-participation actions are valid."
+        )
+    return (
+        "You are NOT currently in any interaction. Do not attempt to act in or "
+        "continue an interaction; any belief that you are mid-interaction is stale."
+    )

--- a/mind/src/mind/cognitive_architecture/nodes/formatting.py
+++ b/mind/src/mind/cognitive_architecture/nodes/formatting.py
@@ -5,6 +5,13 @@ rendering logic. Imported by any node that surfaces personality to the LLM
 (cognitive_update, action_selection) so the representation stays identical.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mind.cognitive_architecture.observations import Observation
+
 
 def format_personality(
     traits: list[str],
@@ -33,7 +40,7 @@ def format_personality(
     return traits_text, dims_text
 
 
-def format_interaction_status(observation) -> str:
+def format_interaction_status(observation: Observation | None) -> str:
     """Render the observation's authoritative interaction status for prompts.
 
     Grounds the LLM's "am I interacting?" belief in the current observation

--- a/mind/src/mind/cognitive_architecture/observations/models.py
+++ b/mind/src/mind/cognitive_architecture/observations/models.py
@@ -127,7 +127,7 @@ class StatusObservation(BaseModel):
         """
         if not self.current_interaction:
             return False
-        state_name = self.activity_state.get("state_name", "") if self.activity_state else ""
+        state_name = (self.activity_state or {}).get("state_name", "")
         return state_name == "interacting"
 
 
@@ -348,7 +348,7 @@ class Observation(BaseModel):
                         description="Continue current movement without changes",
                     )
                 )
-            elif state_name == 'interacting' and self.is_interacting():
+            elif self.is_interacting():
                 interaction_name = self.status.current_interaction.get('interaction_name', 'interaction')
                 actions.append(
                     AvailableAction(

--- a/mind/src/mind/cognitive_architecture/observations/models.py
+++ b/mind/src/mind/cognitive_architecture/observations/models.py
@@ -109,6 +109,27 @@ class StatusObservation(BaseModel):
     current_interaction: dict = Field(default_factory=dict)
     activity_state: dict = Field(default_factory=dict)
 
+    def is_interacting(self) -> bool:
+        """Ground "am I in an interaction?" in BOTH authoritative observation signals.
+
+        The simulation can clear ``current_interaction`` and the controller's
+        ``activity_state`` on different frames during interaction teardown
+        (documented cross-field cleanup race in the Godot
+        ``entity_controller._on_interaction_ended`` handler). Requiring BOTH
+        signals to agree avoids treating a half-torn-down state as "still
+        interacting", which is the upstream cause of the act_in_interaction
+        desync loop (NPC-688).
+
+        Backward compatible: an older sim payload without ``activity_state``
+        (or without ``state_name``) safely resolves to ``False`` rather than
+        crashing, so a missing field never produces a spurious interaction
+        action.
+        """
+        if not self.current_interaction:
+            return False
+        state_name = self.activity_state.get("state_name", "") if self.activity_state else ""
+        return state_name == "interacting"
+
 
 class NeedsObservation(BaseModel):
     """Entity needs state"""
@@ -233,6 +254,14 @@ class Observation(BaseModel):
 
         return "\n\n".join(parts) if parts else "No observations"
 
+    def is_interacting(self) -> bool:
+        """Authoritative "am I interacting?" grounded in the current observation.
+
+        Defaults to ``False`` when no status is present so a malformed or
+        partial observation can never advertise interaction-only actions.
+        """
+        return bool(self.status and self.status.is_interacting())
+
     def get_available_actions(self, pending_incoming_bids: dict[str, "MindEvent"] = None):
         """Build list of available actions from this observation.
 
@@ -298,8 +327,10 @@ class Observation(BaseModel):
         )
 
         # Wait action only available when NOT in an active interaction
-        # (wait exits interactions, use cancel_interaction to explicitly end one)
-        if not (self.status and self.status.current_interaction):
+        # (wait exits interactions, use cancel_interaction to explicitly end one).
+        # Grounded on is_interacting() so a half-torn-down state (current_interaction
+        # set but activity_state already non-interacting) still offers wait.
+        if not self.is_interacting():
             actions.append(
                 AvailableAction(
                     name=ActionType.WAIT,
@@ -317,7 +348,7 @@ class Observation(BaseModel):
                         description="Continue current movement without changes",
                     )
                 )
-            elif state_name == 'interacting' and self.status.current_interaction:
+            elif state_name == 'interacting' and self.is_interacting():
                 interaction_name = self.status.current_interaction.get('interaction_name', 'interaction')
                 actions.append(
                     AvailableAction(
@@ -326,8 +357,11 @@ class Observation(BaseModel):
                     )
                 )
 
-        # Conditional: interaction actions only if currently in an interaction
-        if self.status and self.status.current_interaction:
+        # Conditional: interaction actions only when the observation confirms an
+        # active interaction on BOTH signals (current_interaction + activity_state).
+        # Grounding here (not just current_interaction presence) prevents emitting
+        # act_in_interaction during interaction teardown — the NPC-688 desync loop.
+        if self.is_interacting():
             interaction_name = self.status.current_interaction.get('interaction_name', 'interaction')
 
             # Add action to participate in the interaction (e.g., send message in conversation)

--- a/mind/tests/unit/observations/test_interaction_grounding.py
+++ b/mind/tests/unit/observations/test_interaction_grounding.py
@@ -1,0 +1,222 @@
+"""Regression tests for NPC-688: observation-grounded interaction gating.
+
+The MCP mind must ground "am I interacting?" in the current OBSERVATION
+(current_interaction AND activity_state == interacting), never in a stale
+free-text working-memory belief. These tests pin that behavior so the
+act_in_interaction desync loop (NPC-687) cannot structurally recur.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.messages import AIMessage
+from pydantic import ValidationError
+
+from mind.cognitive_architecture.actions import Action, ActionType
+from mind.cognitive_architecture.nodes.action_selection.node import ActionSelectionNode
+from mind.cognitive_architecture.nodes.cognitive_update.models import WorkingMemory
+from mind.cognitive_architecture.nodes.formatting import format_interaction_status
+from mind.cognitive_architecture.observations import (
+    Observation,
+    StatusObservation,
+)
+from mind.cognitive_architecture.state import PipelineState
+
+
+def _interacting_status() -> StatusObservation:
+    return StatusObservation(
+        position=(10, 10),
+        movement_locked=True,
+        current_interaction={"interaction_id": "conv_1", "interaction_name": "conversation"},
+        activity_state={"state_name": "interacting"},
+    )
+
+
+def _torn_down_status() -> StatusObservation:
+    """current_interaction still set but controller already left interacting state.
+
+    Mirrors the cross-field teardown race documented in the Godot
+    entity_controller._on_interaction_ended handler.
+    """
+    return StatusObservation(
+        position=(10, 10),
+        movement_locked=False,
+        current_interaction={"interaction_id": "conv_1", "interaction_name": "conversation"},
+        activity_state={"state_name": "idle"},
+    )
+
+
+def _not_interacting_status() -> StatusObservation:
+    return StatusObservation(
+        position=(10, 10),
+        movement_locked=False,
+        current_interaction={},
+        activity_state={"state_name": "idle"},
+    )
+
+
+class TestIsInteractingGrounding:
+    """is_interacting() requires BOTH authoritative signals to agree."""
+
+    def test_true_only_when_both_signals_agree(self):
+        assert _interacting_status().is_interacting() is True
+
+    def test_false_when_interaction_set_but_state_not_interacting(self):
+        # The teardown race: belief would say "interacting" but state disagrees.
+        assert _torn_down_status().is_interacting() is False
+
+    def test_false_when_no_current_interaction(self):
+        assert _not_interacting_status().is_interacting() is False
+
+    def test_false_when_state_interacting_but_no_interaction(self):
+        status = StatusObservation(
+            position=(0, 0),
+            current_interaction={},
+            activity_state={"state_name": "interacting"},
+        )
+        assert status.is_interacting() is False
+
+    def test_backward_compatible_missing_activity_state_defaults_false(self):
+        # Older sim payload: no activity_state at all. Must not crash and must
+        # NOT report interacting (avoids spurious act_in_interaction).
+        status = StatusObservation(
+            position=(0, 0),
+            current_interaction={"interaction_id": "x", "interaction_name": "conversation"},
+        )
+        assert status.activity_state == {}
+        assert status.is_interacting() is False
+
+    def test_observation_accessor_defaults_false_without_status(self):
+        obs = Observation(entity_id="npc", current_simulation_time=1, status=None)
+        assert obs.is_interacting() is False
+
+
+class TestAvailableActionsGrounding:
+    """get_available_actions must gate interaction actions on is_interacting()."""
+
+    def _action_names(self, status: StatusObservation) -> set[str]:
+        obs = Observation(entity_id="npc", current_simulation_time=1, status=status)
+        return {a.name for a in obs.get_available_actions()}
+
+    def test_offers_act_in_interaction_when_grounded_interacting(self):
+        names = self._action_names(_interacting_status())
+        assert ActionType.ACT_IN_INTERACTION in names
+        assert ActionType.CANCEL_INTERACTION in names
+        assert ActionType.WAIT not in names
+
+    def test_no_act_in_interaction_during_teardown_race(self):
+        # current_interaction set, but activity_state already idle.
+        names = self._action_names(_torn_down_status())
+        assert ActionType.ACT_IN_INTERACTION not in names
+        assert ActionType.CANCEL_INTERACTION not in names
+        # wait becomes available again so the NPC has a safe option.
+        assert ActionType.WAIT in names
+
+    def test_no_act_in_interaction_when_not_interacting(self):
+        names = self._action_names(_not_interacting_status())
+        assert ActionType.ACT_IN_INTERACTION not in names
+        assert ActionType.WAIT in names
+
+
+class TestValidatorGrounding:
+    """The Action validator hard-rejects act_in_interaction when not grounded."""
+
+    def _state(self, status: StatusObservation) -> PipelineState:
+        return PipelineState(
+            observation=Observation(entity_id="npc", current_simulation_time=1, status=status),
+        )
+
+    def test_act_in_interaction_valid_when_grounded(self):
+        state = self._state(_interacting_status())
+        action = Action.model_validate(
+            {"action": "act_in_interaction", "parameters": {"message": "hi"}},
+            context={"state": state},
+        )
+        assert action.action == ActionType.ACT_IN_INTERACTION
+
+    def test_act_in_interaction_rejected_during_teardown_race(self):
+        state = self._state(_torn_down_status())
+        with pytest.raises(ValidationError):
+            Action.model_validate(
+                {"action": "act_in_interaction", "parameters": {"message": "hi"}},
+                context={"state": state},
+            )
+
+    def test_act_in_interaction_rejected_when_not_interacting(self):
+        state = self._state(_not_interacting_status())
+        with pytest.raises(ValidationError):
+            Action.model_validate(
+                {"action": "act_in_interaction", "parameters": {"message": "hi"}},
+                context={"state": state},
+            )
+
+
+class TestInteractionStatusRendering:
+    """format_interaction_status produces a grounded, corrective string."""
+
+    def test_interacting_string_confirms_interaction(self):
+        obs = Observation(entity_id="npc", current_simulation_time=1, status=_interacting_status())
+        text = format_interaction_status(obs)
+        assert "ARE currently in an interaction" in text
+        assert "conversation" in text
+
+    def test_not_interacting_string_marks_belief_stale(self):
+        obs = Observation(entity_id="npc", current_simulation_time=1, status=_torn_down_status())
+        text = format_interaction_status(obs)
+        assert "NOT currently in any interaction" in text
+        assert "stale" in text
+
+    def test_missing_status_defaults_not_interacting(self):
+        obs = Observation(entity_id="npc", current_simulation_time=1, status=None)
+        assert "NOT currently in any interaction" in format_interaction_status(obs)
+
+
+@pytest.mark.asyncio
+class TestActionSelectionRegroundsBelief:
+    """End-to-end node test: stale working-memory belief is overridden.
+
+    Feeds an observation that says NOT interacting plus a working memory that
+    claims "in conversation". The action_selection prompt must surface the
+    grounded status, and the chosen action must not be act_in_interaction.
+    """
+
+    async def test_does_not_emit_act_in_interaction_when_observation_says_not_interacting(self):
+        # LLM mock that would *try* to act in interaction if it could.
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.return_value = AIMessage(
+            content='{"chosen_action": {"action": "wander", "parameters": {}}}',
+            usage_metadata={"input_tokens": 100, "output_tokens": 10, "total_tokens": 110},
+        )
+        node = ActionSelectionNode(mock_llm)
+
+        obs = Observation(
+            entity_id="npc",
+            current_simulation_time=1,
+            status=_torn_down_status(),  # interaction torn down
+        )
+        state = PipelineState(
+            observation=obs,
+            # available_actions built from the grounded observation: no act_in_interaction
+            available_actions=obs.get_available_actions(),
+            working_memory=WorkingMemory(
+                situation_assessment="I am in a conversation with Alice",
+                active_goals=["Continue the conversation"],
+                current_plan=["Reply to Alice"],
+                emotional_state="Engaged",
+            ),
+        )
+
+        # The grounded action set must not include act_in_interaction.
+        offered = {a.name for a in state.available_actions}
+        assert ActionType.ACT_IN_INTERACTION not in offered
+
+        result = await node.process(state)
+
+        # Prompt rendered to the LLM must surface the corrective status.
+        # call_llm invokes self.llm.ainvoke([HumanMessage(content=prompt_text)]).
+        sent_messages = mock_llm.ainvoke.call_args[0][0]
+        rendered_text = "\n".join(getattr(m, "content", str(m)) for m in sent_messages)
+        assert "NOT currently in any interaction" in rendered_text
+
+        # And the emitted action is not an interaction-participation action.
+        assert result.chosen_action.action != ActionType.ACT_IN_INTERACTION

--- a/mind/tests/unit/test_action_selection_node.py
+++ b/mind/tests/unit/test_action_selection_node.py
@@ -240,11 +240,14 @@ class TestActionSelectionNode:
 
     async def test_handles_complex_action_parameters(self, node, mock_llm, basic_state):
         """Should handle actions with multiple complex parameters"""
-        # Set up an active interaction so act_in_interaction is valid
+        # Set up an active interaction so act_in_interaction is valid.
+        # NPC-688: validity is grounded in BOTH current_interaction AND
+        # activity_state == interacting, so set both authoritative signals.
         basic_state.observation.status.current_interaction = {
             "interaction_id": "conversation_123",
             "interaction_name": "chat",
         }
+        basic_state.observation.status.activity_state = {"state_name": "interacting"}
 
         mock_llm.ainvoke.return_value = AIMessage(
             content="""{


### PR DESCRIPTION
## Summary
Root-cause fix for the `act_in_interaction` desync loop (NPC-687): the "am I interacting" belief lived only in free-text working memory and was never re-grounded against the observation, so the LLM kept choosing conversational actions after the interaction had torn down.

- `StatusObservation.is_interacting()` / `Observation.is_interacting()` require **both** authoritative signals to agree (`current_interaction` set AND `activity_state.state_name == "interacting"`) — mirrors the cross-field teardown race documented on the Godot side (`entity_controller._on_interaction_ended`).
- Re-gate `get_available_actions()` (ACT_IN_INTERACTION, CANCEL_INTERACTION, CONTINUE-in-interaction, WAIT) and the action validator on `is_interacting()` instead of `current_interaction` presence alone.
- Inject a grounded interaction-status string into **both** the `cognitive_update` and `action_selection` prompts (shared `formatting.format_interaction_status`), correcting a stale working-memory belief each cycle.
- Backward compatible: an older sim payload missing `activity_state` safely resolves to not-interacting rather than crashing.

## Risks and trade-offs
**Complementarity:** This is the *upstream cause* fix. The Godot sim repo has two companion PRs: a downstream controller guard + backoff (NPC-687) and a test-only observation-contract pin (NPC-688 sim side). This PR does not reimplement the controller guard.

**Backward-compat:** the `is_interacting()` helper reads `activity_state.get("state_name", "")` guarded for a missing `activity_state`, resolving to `False` — so an older sim never crashes and never advertises a spurious interaction action. This is the main compatibility risk surface and it's handled defensively.

**Behavior change:** WAIT is now offered again during a half-torn-down state (previously suppressed). Intentional — gives the mind a valid no-op while grounded as not-interacting, instead of forcing an invalid interaction action.

**Verification:** `pytest tests/unit` → **152 passed** twice (136 baseline + 16 new), stable. ruff clean on changed files. One pre-existing unrelated ruff `I001` in `tests/unit/test_action_selection_node.py` left untouched (present on HEAD, out of scope). One pre-existing fixture updated (it modeled an ungrounded "interaction" — now sets `activity_state.state_name` so it represents a genuinely grounded interaction; the validator was not weakened).

**Recommendation:** Ship alongside the sim-side contract PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Thread 4: Substrate