### PR TITLE
ci: add automatic Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,99 @@
+name: Claude Auto Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          additional_permissions: |
+            actions: read
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are reviewing a pull request for the NPC "Mind tier" repository: a
+            Python MCP (Model Context Protocol) server providing LLM-based
+            decision-making and memory for the Godot NPC simulation. The project
+            conventions live in `mind/CLAUDE.md` (the Python package is rooted at
+            `mind/src/mind/`, NOT the git root). Read it before reviewing.
+
+            Review the diff against these standards. Post specific, actionable
+            inline comments; do not restate the whole diff. Be concise and high-signal.
+
+            ## Python style and tooling
+            - Code must satisfy ruff (config in `mind/pyproject.toml`): rules
+              E, W, F, I (isort), B (bugbear), C4, UP (pyupgrade); line-length 100;
+              double-quoted strings; spaces for indentation. Flag obvious ruff
+              violations (unused imports, unsorted imports, mutable-default args,
+              non-pyupgraded syntax, f-strings missing placeholders).
+            - Type safety: the project uses Pydantic v2 models and mypy
+              (`--ignore-missing-imports --no-strict-optional`). Prefer typed
+              signatures and Pydantic models over raw dicts for structured data.
+              Flag new public functions / Node methods that drop type annotations.
+            - Follow the existing module layout: cognitive_architecture/ (pipeline,
+              nodes, memory), interfaces/mcp/ (FastMCP server), apis/ (LLM clients).
+              New processing nodes extend the Node / LLMNode base classes in
+              `cognitive_architecture/nodes/base.py` and keep their prompt in a
+              sibling `prompt.md`.
+
+            ## Architecture
+            - This is the Mind tier of a three-tier system (Controller -> Client ->
+              Mind). It must stay free of Godot/engine dependencies and must not
+              assume a particular simulation client.
+            - The cognitive pipeline is a 4-step async LangGraph StateGraph:
+              memory_query -> memory_retrieval -> cognitive_update ->
+              action_selection (plus on-demand memory_consolidation). State flows
+              through the `PipelineState` model. Flag changes that bypass the
+              pipeline, mutate shared state unsafely, or break the node contract.
+            - MCP surface (create_mind / decide_action / consolidate_memories /
+              cleanup_mind and the mind:// resources): flag changes to tool
+              signatures or returned shapes that would break the Godot client
+              without a corresponding note, and ensure observation/action payloads
+              stay serializable.
+            - Memory: ChromaDB vector store with ID-based deduplication, importance
+              scoring, recency decay, and a daily buffer consolidated on demand.
+              Flag changes that could leak duplicates, drop importance/recency
+              handling, or break consolidation.
+            - LLM calls go through the OpenRouter-backed clients in `apis/`; flag
+              hardcoded keys, missing async handling, or unbounded token usage.
+
+            ## Testing
+            - Tests use pytest (`asyncio_mode = auto`), split into
+              `mind/tests/unit/` and `mind/tests/integration/`; run via
+              `poetry run pytest`. Test files are named `test_*.py`.
+            - New behavior should add unit tests; bug fixes should add a regression
+              test that fails before the fix. Flag new logic with no test coverage
+              and bug-fix PRs with no regression test.
+            - Prefer fast unit tests (the pre-commit hook runs `tests/unit`);
+              reserve integration tests for MCP server / pipeline / ChromaDB
+              boundaries.
+
+            ## Hygiene
+            - No secrets / API keys committed; configuration comes from the
+              environment (e.g. OPENROUTER_API_KEY).
+            - Notebooks are stripped by nbstripout - flag committed notebook outputs.
+            - Keep docstrings and docs accurate; per
+              `mind/docs/meta/style-guide.md`, docs should be concise and
+              purpose-focused.
+
+            If the PR looks good, say so briefly and note anything worth a
+            follow-up. Otherwise concentrate on correctness, the pipeline / MCP
+            contracts, and missing tests.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` so `claude-code-action` reviews every PR automatically (`opened`, `synchronize`, `ready_for_review`, `reopened`), mirroring the sibling Godot sim repo which already has auto-review. The repo previously had **no `.github/` at all** — that was the root cause of "no automatic review."
- The review prompt is tailored to this **Python MCP Mind-tier repo** (not the Godot sim): ruff/mypy + Pydantic v2 typing, the 4-step LangGraph pipeline and MCP tool/resource contracts, ChromaDB memory invariants (dedup/importance/recency/consolidation), and pytest unit/regression coverage. It directs the reviewer to read `mind/CLAUDE.md` (conventions live there, not at the git root).
- Uses the existing `ANTHROPIC_API_KEY` repo secret — no new secret needed.

## Notes
- `@claude` mentions already work via the hosted GitHub App, so no `claude.yml` mention-handler workflow was added (would duplicate the app and risk double-responses).
- **Gemini auto-review is a separate, app-install concern.** The sim repo has no `.gemini/` config either — Gemini Code Assist auto-reviews by app default *once installed*. Gemini almost certainly isn't auto-running here because the app isn't enabled on this repo. **User action:** install/enable Gemini Code Assist on `taylor1355/npc` at https://github.com/apps/gemini-code-assist. No code change can produce Gemini auto-review without that.

## Test plan
- [ ] Open a test PR and confirm the "Claude Auto Review" workflow runs and posts review comments
- [ ] (User action) Install Gemini Code Assist on this repo to enable Gemini auto-review

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Thread 1: DX