### PR TITLE
Wire real cosine similarity into memory combined scoring

### DIFF
--- a/mind/src/mind/cognitive_architecture/memory/vector_db_memory.py
+++ b/mind/src/mind/cognitive_architecture/memory/vector_db_memory.py
@@ -56,9 +56,21 @@ class ChromaQueryResult(BaseModel):
         """Get metadatas from first query result"""
         return self.metadatas[0] if self.metadatas else []
 
+    @property
+    def first_query_distances(self) -> list[float | None]:
+        """Get cosine distances from first query result, or Nones when absent"""
+        if self.distances and self.distances[0]:
+            return list(self.distances[0])
+        return [None] * len(self.first_query_ids)
+
     def iter_first_query(self):
-        """Iterate over (id, document, metadata) tuples for first query"""
-        return zip(self.first_query_ids, self.first_query_documents, self.first_query_metadatas)
+        """Iterate over (id, document, metadata, distance) tuples for first query"""
+        return zip(
+            self.first_query_ids,
+            self.first_query_documents,
+            self.first_query_metadatas,
+            self.first_query_distances,
+        )
 
 
 class VectorDBMemory:
@@ -159,7 +171,9 @@ class VectorDBMemory:
             return []
 
         raw_results = self.collection.query(
-            query_embeddings=[query_embedding], n_results=min(query.top_k, collection_count)
+            query_embeddings=[query_embedding],
+            n_results=min(query.top_k, collection_count),
+            include=["documents", "metadatas", "distances"],
         )
 
         # Parse into typed model
@@ -171,12 +185,18 @@ class VectorDBMemory:
         # Convert results to Memory objects with combined scoring
         memories = []
 
-        for memory_id, content, metadata_dict in results.iter_first_query():
+        for memory_id, content, metadata_dict, distance in results.iter_first_query():
             # Parse metadata with type safety
             metadata = VectorDBMetadata.model_validate(metadata_dict)
 
-            # Calculate combined score
-            similarity_score = 1.0  # ChromaDB returns sorted by similarity
+            # Calculate combined score. The collection uses cosine space, so the
+            # ChromaDB distance is (1 - cosine_similarity). Convert back to a
+            # similarity in [0, 1] (clamped); fall back to 1.0 when a backend
+            # omits distances so older/partial results still rank deterministically.
+            if distance is None:
+                similarity_score = 1.0
+            else:
+                similarity_score = max(0.0, min(1.0, 1.0 - distance))
             importance_score = metadata.importance / 10.0
 
             # Calculate recency score if we have timestamps

--- a/mind/tests/unit/test_vector_db_memory.py
+++ b/mind/tests/unit/test_vector_db_memory.py
@@ -176,3 +176,38 @@ class TestVectorDBMemory:
 
         assert len(results) == 1
         assert results[0].id == original_id
+
+    async def test_similarity_influences_ranking(self, memory_store):
+        """High-similarity/low-importance should outrank low-similarity/high-importance.
+
+        Regression for the bug where similarity_score was hardcoded to 1.0,
+        making the combined score depend only on importance + recency. With a
+        modest importance_weight, real semantic similarity must be able to flip
+        the ranking in favor of the more relevant (but less important) memory.
+        """
+        # On-topic but low importance.
+        memory_store.add_memory(
+            content="The blacksmith forged a gleaming steel sword at the forge",
+            importance=1.0,
+        )
+        # Off-topic but high importance.
+        memory_store.add_memory(
+            content="A gentle rain fell over the quiet meadow at dawn",
+            importance=10.0,
+        )
+
+        # Modest importance weight: similarity should dominate.
+        query = VectorDBQuery(
+            query="forging a sword at the blacksmith forge",
+            top_k=2,
+            importance_weight=0.2,
+            recency_weight=0.0,
+        )
+        results = await memory_store.search(query)
+
+        assert len(results) == 2
+        # The semantically relevant (low-importance) memory must rank first,
+        # which is only possible once real similarity feeds the combined score.
+        assert "sword" in results[0].content.lower()
+        assert results[0].importance < results[1].importance
+


### PR DESCRIPTION
## Summary
`VectorDBMemory.search()` hardcoded `similarity_score = 1.0` for every result, so the combined relevance score was driven only by importance + recency — semantic similarity was discarded after ChromaDB's initial top_k selection. The real per-result distances were parsed (`ChromaQueryResult.distances`) but never read.

This wires the real cosine similarity into the score:
- `collection.query(..., include=["documents","metadatas","distances"])` requests distances explicitly.
- `similarity_score = max(0.0, min(1.0, 1.0 - distance))` (cosine space → distance ≈ 1 − cosine_similarity), with a `1.0` fallback when distances are absent.
- `iter_first_query()` threads the per-result distance through; importance/recency weights unchanged.

## Test plan
- New `test_similarity_influences_ranking`: an on-topic/low-importance memory outranks an off-topic/high-importance one under modest `importance_weight` — fails against the old constant-similarity code, passes with the fix.
- `poetry run pytest` ×2: 171 passed, 2 pre-existing failures unrelated (OpenRouter model 404).

🤖 Generated with [Claude Code]