### PR TITLE
Attribute cognitive pipeline log lines to their NPC (NPC-789)

### DIFF
--- a/mind/src/mind/cognitive_architecture/nodes/action_selection/node.py
+++ b/mind/src/mind/cognitive_architecture/nodes/action_selection/node.py
@@ -9,7 +9,7 @@ from langchain_core.prompts import PromptTemplate
 from pydantic import ValidationError
 
 from mind.cognitive_architecture.actions import Action, ActionType
-from mind.cognitive_architecture.nodes.base import LLMNode
+from mind.cognitive_architecture.nodes.base import LLMNode, entity_tag
 from mind.cognitive_architecture.nodes.formatting import (
     format_interaction_status as _format_interaction_status,
 )
@@ -72,7 +72,7 @@ class ActionSelectionNode(LLMNode):
                 format_instructions=self.get_format_instructions()
             )
         except (ValidationError, json.JSONDecodeError) as e:
-            logger.warning(f"Action selection failed after retries, falling back to wait: {e}")
+            logger.warning(f"{entity_tag(state)} Action selection failed after retries, falling back to wait: {e}")
             # Use model_construct to bypass validation - WAIT is always safe
             fallback_action = Action.model_construct(action=ActionType.WAIT, parameters={})
             output = ActionSelectionOutput.model_construct(chosen_action=fallback_action)
@@ -91,7 +91,8 @@ class ActionSelectionNode(LLMNode):
         state.recent_events.append(action_event)
 
         # Log action selection
-        logger.debug(f"Evaluated {len(state.available_actions)} available actions")
-        logger.debug(f"Selected: {output.chosen_action}")
+        tag = entity_tag(state)
+        logger.debug(f"{tag} Evaluated {len(state.available_actions)} available actions")
+        logger.debug(f"{tag} Selected: {output.chosen_action}")
 
         return state

--- a/mind/src/mind/cognitive_architecture/nodes/base.py
+++ b/mind/src/mind/cognitive_architecture/nodes/base.py
@@ -23,7 +23,7 @@ def entity_tag(state: PipelineState) -> str:
     The simulation forwards /logs lines to an NPC's Events tab by matching the
     entity id in the message text, so every per-entity log line must carry it.
     """
-    if state.observation is not None and state.observation.entity_id:
+    if state is not None and state.observation is not None and state.observation.entity_id:
         return f"[{state.observation.entity_id}]"
     return "[unknown]"
 

--- a/mind/src/mind/cognitive_architecture/nodes/base.py
+++ b/mind/src/mind/cognitive_architecture/nodes/base.py
@@ -17,6 +17,17 @@ from mind.logging_config import get_logger
 logger = get_logger()
 
 
+def entity_tag(state: PipelineState) -> str:
+    """Bracketed entity id for per-NPC log attribution.
+
+    The simulation forwards /logs lines to an NPC's Events tab by matching the
+    entity id in the message text, so every per-entity log line must carry it.
+    """
+    if state.observation is not None and state.observation.entity_id:
+        return f"[{state.observation.entity_id}]"
+    return "[unknown]"
+
+
 class Node(ABC):
     """Base class for all pipeline nodes - adds automatic timing"""
 
@@ -120,7 +131,7 @@ class LLMNode(Node):
             tokens = self._extract_tokens(response)
             if tokens:
                 state.tokens_used[self.step_name] = tokens
-            logger.debug(f"[{self.step_name}] Completed in {elapsed_ms}ms, {tokens} tokens")
+            logger.debug(f"{entity_tag(state)} [{self.step_name}] Completed in {elapsed_ms}ms, {tokens} tokens")
             return response.content
 
         # Structured output with retry
@@ -150,7 +161,7 @@ class LLMNode(Node):
                 elapsed_ms = int((time.time() - start_time) * 1000)
                 if total_tokens:
                     state.tokens_used[self.step_name] = total_tokens
-                logger.debug(f"[{self.step_name}] Completed in {elapsed_ms}ms, {total_tokens} tokens")
+                logger.debug(f"{entity_tag(state)} [{self.step_name}] Completed in {elapsed_ms}ms, {total_tokens} tokens")
                 return validated
 
             except (json.JSONDecodeError, ValidationError) as e:
@@ -158,7 +169,7 @@ class LLMNode(Node):
                 if attempt < max_attempts - 1:
                     # Log retry
                     error_type = "JSONDecodeError" if isinstance(e, json.JSONDecodeError) else "ValidationError"
-                    logger.debug(f"[{self.step_name}] Retry {attempt + 1}/{self.max_retries}: {error_type}")
+                    logger.debug(f"{entity_tag(state)} [{self.step_name}] Retry {attempt + 1}/{self.max_retries}: {error_type}")
 
                     messages.append(AIMessage(content=response.content))
 

--- a/mind/src/mind/cognitive_architecture/nodes/cognitive_update/node.py
+++ b/mind/src/mind/cognitive_architecture/nodes/cognitive_update/node.py
@@ -6,7 +6,7 @@ from pprint import pformat
 from langchain_core.language_models import BaseChatModel
 from langchain_core.prompts import PromptTemplate
 
-from mind.cognitive_architecture.nodes.base import LLMNode
+from mind.cognitive_architecture.nodes.base import LLMNode, entity_tag
 from mind.cognitive_architecture.nodes.formatting import (
     format_interaction_status as _format_interaction_status,
 )
@@ -81,17 +81,23 @@ class CognitiveUpdateNode(LLMNode):
         # Add new memories to daily buffer
         state.daily_memories.extend(output.new_memories)
 
-        # Log updated working memory
+        # Log updated working memory as a single record so the simulation's
+        # Events tab shows one entry per thought instead of one per field
+        tag = entity_tag(state)
         wm = output.updated_working_memory
-        logger.debug("Updated working memory:")
-        logger.debug(f"  Situation: {wm.situation_assessment}")
-        logger.debug(f"  Active goals: {wm.active_goals}")
-        logger.debug(f"  Current plan: {wm.current_plan}")
-        logger.debug(f"  Emotional state: {wm.emotional_state}")
+        logger.debug(
+            f"{tag} Updated working memory:\n"
+            f"  Situation: {wm.situation_assessment}\n"
+            f"  Active goals: {wm.active_goals}\n"
+            f"  Current plan: {wm.current_plan}\n"
+            f"  Emotional state: {wm.emotional_state}"
+        )
 
-        # Log new memories
-        logger.debug(f"Storing {len(output.new_memories)} new memories")
-        for mem in output.new_memories:
-            logger.debug(f"  [importance={mem.importance}] {mem.content}")
+        # Log new memories as a single record for the same reason
+        memory_lines = "".join(
+            f"\n  [importance={mem.importance}] {mem.content}"
+            for mem in output.new_memories
+        )
+        logger.debug(f"{tag} Storing {len(output.new_memories)} new memories{memory_lines}")
 
         return state

--- a/mind/src/mind/cognitive_architecture/nodes/memory_query/node.py
+++ b/mind/src/mind/cognitive_architecture/nodes/memory_query/node.py
@@ -7,7 +7,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import PromptTemplate
 
-from mind.cognitive_architecture.nodes.base import LLMNode
+from mind.cognitive_architecture.nodes.base import LLMNode, entity_tag
 from mind.cognitive_architecture.state import PipelineState
 from mind.logging_config import get_logger
 
@@ -38,5 +38,5 @@ class MemoryQueryNode(LLMNode):
         )
 
         state.memory_queries = output.queries
-        logger.debug(f"Generated {len(output.queries)} memory queries: {output.queries}")
+        logger.debug(f"{entity_tag(state)} Generated {len(output.queries)} memory queries: {output.queries}")
         return state

--- a/mind/src/mind/cognitive_architecture/nodes/memory_retrieval/node.py
+++ b/mind/src/mind/cognitive_architecture/nodes/memory_retrieval/node.py
@@ -7,7 +7,7 @@ from mind.logging_config import get_logger
 from ...memory import Memory
 from ...memory.vector_db_memory import VectorDBQuery
 from ...state import PipelineState
-from ..base import Node
+from ..base import Node, entity_tag
 
 logger = get_logger()
 
@@ -62,10 +62,10 @@ class MemoryRetrievalNode(Node):
         state.retrieved_memories = deduplicated_memories
 
         # Log retrieved memories
-        entity_id = state.observation.entity_id if state.observation else "unknown"
-        logger.debug(f"[{entity_id}] Retrieved {len(deduplicated_memories)} memories from {len(state.memory_queries)} queries")
+        tag = entity_tag(state)
+        logger.debug(f"{tag} Retrieved {len(deduplicated_memories)} memories from {len(state.memory_queries)} queries")
         for i, mem in enumerate(deduplicated_memories[:3]):  # Show top 3
             content_preview = mem.content[:100] + "..." if len(mem.content) > 100 else mem.content
-            logger.debug(f"[{entity_id}]   [{i+1}] {content_preview}")
+            logger.debug(f"{tag}   [{i+1}] {content_preview}")
 
         return state

--- a/mind/src/mind/cognitive_architecture/pipeline.py
+++ b/mind/src/mind/cognitive_architecture/pipeline.py
@@ -7,6 +7,7 @@ from mind.logging_config import get_logger
 
 from .memory.vector_db_memory import VectorDBMemory
 from .nodes.action_selection.node import ActionSelectionNode
+from .nodes.base import entity_tag
 from .nodes.cognitive_update.node import CognitiveUpdateNode
 from .nodes.memory_query.node import MemoryQueryNode
 from .nodes.memory_retrieval.node import MemoryRetrievalNode
@@ -55,7 +56,7 @@ class CognitivePipeline:
 
     async def process(self, state: PipelineState) -> PipelineState:
         """Process an observation through the cognitive pipeline"""
-        logger.debug(f"Pipeline starting for entity_id={state.observation.entity_id}")
+        logger.debug(f"{entity_tag(state)} Pipeline starting")
 
         result_dict = await self.chain.ainvoke(state)
         # Convert LangGraph's AddableValuesDict back to our Pydantic model
@@ -65,6 +66,6 @@ class CognitivePipeline:
         # Log pipeline completion summary
         total_time = sum(result.time_ms.values())
         total_tokens = sum(result.tokens_used.values())
-        logger.debug(f"Pipeline completed in {total_time}ms, {total_tokens} tokens")
+        logger.debug(f"{entity_tag(state)} Pipeline completed in {total_time}ms, {total_tokens} tokens")
 
         return result

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -59,7 +59,9 @@ def _extract_conversation_observations(
 
     Args:
         events: List of MindEvent objects
-        mind_id: Mind these events belong to (for per-NPC log attribution)
+        mind_id: Mind these events belong to (for per-NPC log attribution; must carry the
+            entity-id shape the sim /logs forwarder matches — it does,
+            mind_id == entity_id per models.py)
 
     Returns:
         List of ConversationObservation objects parsed from interaction observation events
@@ -85,7 +87,9 @@ def _cleanup_responded_bids(action, pending_bids: dict, request_id: str, mind_id
         action: The chosen action (Action model)
         pending_bids: Dict of pending incoming bids (modified in place)
         request_id: Request ID for logging
-        mind_id: Mind the bids belong to (for per-NPC log attribution)
+        mind_id: Mind the bids belong to (for per-NPC log attribution; must carry the
+            entity-id shape the sim /logs forwarder matches — it does,
+            mind_id == entity_id per models.py)
     """
     if not action:
         return

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -52,11 +52,14 @@ def _success_response(request_id: str, action: dict) -> dict:
     }
 
 
-def _extract_conversation_observations(events: list[MindEvent]) -> list[ConversationObservation]:
+def _extract_conversation_observations(
+    events: list[MindEvent], mind_id: str
+) -> list[ConversationObservation]:
     """Extract conversation observations from INTERACTION_OBSERVATION events.
 
     Args:
         events: List of MindEvent objects
+        mind_id: Mind these events belong to (for per-NPC log attribution)
 
     Returns:
         List of ConversationObservation objects parsed from interaction observation events
@@ -70,18 +73,19 @@ def _extract_conversation_observations(events: list[MindEvent]) -> list[Conversa
                 conversations.append(conv_obs)
             except ValidationError as e:
                 # Not a conversation observation or malformed - skip it
-                logger.debug(f"Skipping non-conversation interaction observation: {e}")
+                logger.debug(f"[{mind_id}] Skipping non-conversation interaction observation: {e}")
                 continue
     return conversations
 
 
-def _cleanup_responded_bids(action, pending_bids: dict, request_id: str) -> None:
+def _cleanup_responded_bids(action, pending_bids: dict, request_id: str, mind_id: str) -> None:
     """Remove bids from pending list after responding to them.
 
     Args:
         action: The chosen action (Action model)
         pending_bids: Dict of pending incoming bids (modified in place)
         request_id: Request ID for logging
+        mind_id: Mind the bids belong to (for per-NPC log attribution)
     """
     if not action:
         return
@@ -91,7 +95,7 @@ def _cleanup_responded_bids(action, pending_bids: dict, request_id: str) -> None
         bid_id = action.parameters.get("bid_id")
         if bid_id and bid_id in pending_bids:
             pending_bids.pop(bid_id)
-            logger.debug(f"[{request_id}] Removed bid {bid_id} from pending bids after response")
+            logger.debug(f"[{request_id}] [{mind_id}] Removed bid {bid_id} from pending bids after response")
 
     elif action.action == ActionType.BATCH_REJECT_INTERACTION_BIDS:
         # Batch bid rejection
@@ -120,7 +124,7 @@ def _cleanup_responded_bids(action, pending_bids: dict, request_id: str) -> None
         for bid_id in bid_ids_to_remove:
             pending_bids.pop(bid_id, None)
 
-        logger.debug(f"[{request_id}] Batch rejected {len(bid_ids_to_remove)} bids: {bid_ids_to_remove}")
+        logger.debug(f"[{request_id}] [{mind_id}] Batch rejected {len(bid_ids_to_remove)} bids: {bid_ids_to_remove}")
 
 
 class MCPServer:
@@ -209,7 +213,7 @@ class MCPServer:
                         )
 
                 # Extract conversation observations from INTERACTION_OBSERVATION events
-                conversation_obs = _extract_conversation_observations(mind_events)
+                conversation_obs = _extract_conversation_observations(mind_events, mind_id)
                 mind.update_conversations(conversation_obs)
                 mind.update_events(mind_events, obs.current_simulation_time)
 
@@ -233,7 +237,7 @@ class MCPServer:
                 mind.event_buffer = result.recent_events
 
                 # Clean up any bids that were responded to
-                _cleanup_responded_bids(result.chosen_action, mind.pending_incoming_bids, request_id)
+                _cleanup_responded_bids(result.chosen_action, mind.pending_incoming_bids, request_id, mind_id)
 
                 if result.chosen_action is None:
                     logger.warning(f"[{request_id}] Pipeline returned no action for {mind_id}")

--- a/mind/tests/unit/test_action_selection_node.py
+++ b/mind/tests/unit/test_action_selection_node.py
@@ -1,5 +1,6 @@
 """Unit tests for ActionSelectionNode"""
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -269,3 +270,32 @@ class TestActionSelectionNode:
         assert result.chosen_action.parameters["interaction_id"] == "conversation_123"
         assert result.chosen_action.parameters["response"] == "I agree to help"
         assert result.chosen_action.parameters["intensity"] == 0.8
+
+    async def test_all_log_records_carry_entity_id(self, node, mock_llm, basic_state, caplog):
+        """Every record from process() must carry the entity id so the simulation's
+        log forwarder can attribute it to the NPC's Events tab (NPC-789)"""
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            await node.process(basic_state)
+
+        assert caplog.records, "process() should emit log records"
+        for record in caplog.records:
+            assert "test_npc" in record.getMessage(), (
+                f"Unattributed log record: {record.getMessage()!r}"
+            )
+
+    async def test_fallback_log_records_carry_entity_id(self, node, mock_llm, basic_state, caplog):
+        """Retry and fallback-warning records must also carry the entity id (NPC-789)"""
+        mock_llm.ainvoke.return_value = AIMessage(
+            content="not valid json",
+            usage_metadata={"input_tokens": 10, "output_tokens": 3, "total_tokens": 13},
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            result = await node.process(basic_state)
+
+        assert result.chosen_action.action == ActionType.WAIT
+        assert caplog.records, "fallback path should emit log records"
+        for record in caplog.records:
+            assert "test_npc" in record.getMessage(), (
+                f"Unattributed log record: {record.getMessage()!r}"
+            )

--- a/mind/tests/unit/test_base_node.py
+++ b/mind/tests/unit/test_base_node.py
@@ -1,5 +1,6 @@
 """Unit tests for base node classes"""
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -7,7 +8,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.prompts import PromptTemplate
 from pydantic import BaseModel, ValidationError
 
-from mind.cognitive_architecture.nodes.base import LLMNode, Node
+from mind.cognitive_architecture.nodes.base import LLMNode, Node, entity_tag
 from mind.cognitive_architecture.state import PipelineState
 from mind.cognitive_architecture.observations import Observation, StatusObservation
 
@@ -425,3 +426,87 @@ class TestTokenExtraction:
 
         tokens = node._extract_tokens(response)
         assert tokens == 0
+
+
+class TestEntityTagAttribution:
+    """NPC-789: log records must carry the entity id for Events-tab attribution"""
+
+    def _make_state(self, entity_id="entity_attribution_test"):
+        return PipelineState(
+            observation=Observation(
+                entity_id=entity_id,
+                current_simulation_time=0,
+                status=StatusObservation(position=(0, 0), movement_locked=False),
+            )
+        )
+
+    def test_entity_tag_brackets_entity_id(self):
+        """Should wrap the entity id in brackets, matching per-entity log convention"""
+        state = self._make_state("npc_alice")
+        assert entity_tag(state) == "[npc_alice]"
+
+    def test_entity_tag_falls_back_when_entity_id_empty(self):
+        """Should produce a recognizable fallback instead of an empty tag"""
+        state = self._make_state("")
+        assert entity_tag(state) == "[unknown]"
+
+    @pytest.mark.asyncio
+    async def test_raw_string_log_records_carry_entity_id(self, caplog):
+        """call_llm raw-string path must emit only attributed records"""
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.return_value = AIMessage(
+            content="Response",
+            usage_metadata={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+        node = LLMNode(
+            llm=mock_llm,
+            prompt=PromptTemplate.from_template("{input}"),
+            output_model=None,
+        )
+        node.step_name = "raw_step"
+        state = self._make_state()
+
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            await node.call_llm(state, input="hi")
+
+        assert caplog.records, "call_llm should emit log records"
+        for record in caplog.records:
+            assert "entity_attribution_test" in record.getMessage(), (
+                f"Unattributed log record: {record.getMessage()!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_retry_log_records_carry_entity_id(self, caplog):
+        """call_llm retry path must emit only attributed records"""
+        class TestOutput(BaseModel):
+            value: str
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.side_effect = [
+            AIMessage(
+                content="not valid json",
+                usage_metadata={"input_tokens": 10, "output_tokens": 3, "total_tokens": 13},
+            ),
+            AIMessage(
+                content='{"value": "success"}',
+                usage_metadata={"input_tokens": 12, "output_tokens": 4, "total_tokens": 16},
+            ),
+        ]
+        node = LLMNode(
+            llm=mock_llm,
+            prompt=PromptTemplate.from_template("{input}"),
+            output_model=TestOutput,
+            max_retries=1,
+        )
+        node.step_name = "retry_step"
+        state = self._make_state()
+
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            result = await node.call_llm(state, input="hi")
+
+        assert result.value == "success"
+        assert caplog.records, "call_llm should emit log records"
+        for record in caplog.records:
+            assert "entity_attribution_test" in record.getMessage(), (
+                f"Unattributed log record: {record.getMessage()!r}"
+            )

--- a/mind/tests/unit/test_cognitive_update_node.py
+++ b/mind/tests/unit/test_cognitive_update_node.py
@@ -1,5 +1,6 @@
 """Unit tests for CognitiveUpdateNode"""
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -244,3 +245,36 @@ class TestCognitiveUpdateNode:
         rendered = call_args[0][0][0].content
         assert "No specific traits" in rendered
         assert "No personality dimensions provided" in rendered
+
+    async def test_all_log_records_carry_entity_id(self, node, mock_llm, basic_state, caplog):
+        """Every record from process() must carry the entity id so the simulation's
+        log forwarder can attribute it to the NPC's Events tab (NPC-789)"""
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            await node.process(basic_state)
+
+        assert caplog.records, "process() should emit log records"
+        for record in caplog.records:
+            assert "test_npc" in record.getMessage(), (
+                f"Unattributed log record: {record.getMessage()!r}"
+            )
+
+    async def test_working_memory_logged_as_single_record(self, node, mock_llm, basic_state, caplog):
+        """Working-memory fields land in one record: one Events-tab entry per thought"""
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            await node.process(basic_state)
+
+        wm_records = [r for r in caplog.records if "Updated working memory" in r.getMessage()]
+        assert len(wm_records) == 1
+        message = wm_records[0].getMessage()
+        assert "Situation:" in message
+        assert "Active goals:" in message
+        assert "Emotional state:" in message
+
+    async def test_new_memories_logged_as_single_record(self, node, mock_llm, basic_state, caplog):
+        """Memory-storage lines land in one record, not one per memory"""
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            await node.process(basic_state)
+
+        storing_records = [r for r in caplog.records if "Storing" in r.getMessage()]
+        assert len(storing_records) == 1
+        assert "Started sword commission" in storing_records[0].getMessage()

--- a/mind/tests/unit/test_memory_query_node.py
+++ b/mind/tests/unit/test_memory_query_node.py
@@ -1,5 +1,6 @@
 """Unit tests for MemoryQueryNode"""
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -146,3 +147,15 @@ class TestMemoryQueryNode:
         assert len(result.memory_queries) == 3
         assert "old query 1" not in result.memory_queries
         assert "blacksmithing techniques I learned" in result.memory_queries
+
+    async def test_all_log_records_carry_entity_id(self, node, mock_llm, basic_state, caplog):
+        """Every record from process() must carry the entity id so the simulation's
+        log forwarder can attribute it to the NPC's Events tab (NPC-789)"""
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            await node.process(basic_state)
+
+        assert caplog.records, "process() should emit log records"
+        for record in caplog.records:
+            assert "test_npc" in record.getMessage(), (
+                f"Unattributed log record: {record.getMessage()!r}"
+            )

--- a/mind/tests/unit/test_memory_retrieval_node.py
+++ b/mind/tests/unit/test_memory_retrieval_node.py
@@ -1,5 +1,6 @@
 """Unit tests for MemoryRetrievalNode"""
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -137,3 +138,20 @@ class TestMemoryRetrievalNode:
         # Should preserve other fields
         assert result.personality_traits == ["brave", "honest"]
         assert result.observation == state.observation
+
+
+    async def test_all_log_records_carry_entity_id(self, node, mock_memory_store, basic_state, caplog):
+        """Every record from process() must carry the entity id so the simulation's
+        log forwarder can attribute it to the NPC's Events tab (NPC-789)"""
+        mock_memory_store.search.return_value = [
+            Memory(id="mem_1", content="Yesterday I worked on a sword", importance=7.0),
+        ]
+
+        with caplog.at_level(logging.DEBUG, logger="mind"):
+            await node.process(basic_state)
+
+        assert caplog.records, "process() should emit log records"
+        for record in caplog.records:
+            assert "test_npc" in record.getMessage(), (
+                f"Unattributed log record: {record.getMessage()!r}"
+            )


### PR DESCRIPTION
## Summary

Pipeline "thoughts" (working-memory updates, memory queries/retrievals, action selections) were invisible in the simulation's per-NPC Events tab. The Godot forwarder attributes `/logs` lines to an NPC by regex-matching the entity id in the **message text** (`mcp_server_manager.gd`), and most per-entity pipeline lines carried only the step name or request id — so they all fell back to the generic MCP-server source.

- `nodes/base.py`: new `entity_tag(state)` helper (bracketed entity id, `[unknown]` fallback); prefixes `call_llm` completion + retry lines. Explicit per-call prefix rather than a `logging.Filter` so the id lives in the message text itself — visible to caplog tests and any raw `/logs` consumer.
- `memory_query`, `action_selection`, `pipeline`: per-entity lines prefixed via the helper; `memory_retrieval` refactored off its hand-rolled prefix.
- `cognitive_update`: the five working-memory lines and N+1 memory-storage lines consolidate into **one multi-line record each** — one Events-tab entry per thought instead of fragments.
- `interfaces/mcp/server.py`: `mind_id` threaded into `_extract_conversation_observations` / `_cleanup_responded_bids`; their lines keep `[{request_id}]` and add the entity (request correlation intact).
- 10 new caplog-based tests assert every record emitted during `process()` carries the entity id, plus exact-one-record consolidation checks.

Sim-repo counterpart: no Godot changes needed — attribution rides the existing `/logs` message-text contract (NPC-789 in the simulation's Linear).

## Risks and trade-offs

- **Contract is textual**: attribution depends on the sim-side regex `entity_[0-9a-f-]{36}` matching ids embedded in messages. The helper standardizes the format, and the bracketed shape matches the already-working `memory_retrieval`/`mind.py` lines. A structured field would be more robust long-term (UI 2.0 thought surfacing is the planned successor).
- **Multi-line records**: consolidated working-memory records contain real newlines in one `LogRecord`. The sim's `/logs` JSON transport handles this (message is a JSON string), but Events-tab rendering of multi-line entries is worth one eyeball during manual testing.
- **Log volume unchanged** in count terms (actually reduced — consolidation removes ~5 records per decision cycle).

## Test plan

Automated: `pytest tests/unit` — 163 passed, run twice identically (10 new attribution tests included).

Manual (in the simulation, after this merges and the server restarts from main):
- [ ] Switch an NPC to `mind mcp`, open its entity window → Events tab
- [ ] Confirm thought entries appear attributed to that NPC: memory queries, retrieved memories, a consolidated "Updated working memory" block, and "Selected: <action>"
- [ ] Confirm server lifecycle chatter (startup, ports) still lands under the generic MCP source, not misattributed

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Thread 4: Substrate & Minds
