### PR TITLE
Decouple mind_id (PK) from entity_id (FK) at the MCP boundary (NPC-795, mind half)

### DIFF
--- a/mind/CLAUDE.md
+++ b/mind/CLAUDE.md
@@ -92,7 +92,7 @@ class WorkingMemory(BaseModel):
 
 ### Tools
 
-- **`create_mind(mind_id, config)`** - Initialize cognitive pipeline with traits and seed memories
+- **`create_mind(mind_id, entity_id, config)`** - Initialize a mind. `mind_id` (PK) keys the mind/memory collection, `entity_id` (FK) names the driven simulation entity, `config` (MindConfig) carries cognition-only settings (traits, seed memories, LLM/personality). `entity_id` is no longer a MindConfig field
 - **`decide_action(mind_id, observation)`** - Process structured observation → action dict
 - **`consolidate_memories(mind_id)`** - Transfer daily memories → long-term storage
 - **`cleanup_mind(mind_id)`** - Remove mind instance and free resources

--- a/mind/CLAUDE.md
+++ b/mind/CLAUDE.md
@@ -93,7 +93,7 @@ class WorkingMemory(BaseModel):
 ### Tools
 
 - **`create_mind(mind_id, entity_id, config)`** - Initialize a mind. `mind_id` (PK) keys the mind/memory collection, `entity_id` (FK) names the driven simulation entity, `config` (MindConfig) carries cognition-only settings (traits, seed memories, LLM/personality). `entity_id` is no longer a MindConfig field
-- **`decide_action(mind_id, observation)`** - Process structured observation → action dict
+- **`decide_action(mind_id, observation, events)`** - Process structured observation + events → action dict
 - **`consolidate_memories(mind_id)`** - Transfer daily memories → long-term storage
 - **`cleanup_mind(mind_id)`** - Remove mind instance and free resources
 

--- a/mind/README.md
+++ b/mind/README.md
@@ -66,7 +66,7 @@ The Godot simulation connects to this server for NPC cognitive processing.
 
 ## MCP Tools
 
-- **`create_mind(mind_id, config)`** - Initialize cognitive pipeline
+- **`create_mind(mind_id, entity_id, config)`** - Initialize cognitive pipeline
 - **`decide_action(mind_id, observation, events)`** - Process observation + events → action
 - **`consolidate_memories(mind_id)`** - Move daily → long-term storage
 - **`cleanup_mind(mind_id)`** - Remove mind instance

--- a/mind/README.md
+++ b/mind/README.md
@@ -67,7 +67,7 @@ The Godot simulation connects to this server for NPC cognitive processing.
 ## MCP Tools
 
 - **`create_mind(mind_id, config)`** - Initialize cognitive pipeline
-- **`decide_action(mind_id, observation)`** - Process observation → action
+- **`decide_action(mind_id, observation, events)`** - Process observation + events → action
 - **`consolidate_memories(mind_id)`** - Move daily → long-term storage
 - **`cleanup_mind(mind_id)`** - Remove mind instance
 

--- a/mind/docs/README.md
+++ b/mind/docs/README.md
@@ -62,7 +62,7 @@ The MCP server (`src/mind/interfaces/mcp/`) provides network access to minds via
 - Dictionary-based registry manages active mind instances
 
 **Tools:**
-- `create_mind(mind_id, config)`: Initialize mind with cognitive pipeline
+- `create_mind(mind_id, entity_id, config)`: Initialize mind with cognitive pipeline
 - `decide_action(mind_id, observation, events)`: Process structured observation + events → action dict
 - `consolidate_memories(mind_id)`: Transfer daily → long-term storage
 - `cleanup_mind(mind_id)`: Remove mind and free resources

--- a/mind/docs/README.md
+++ b/mind/docs/README.md
@@ -63,7 +63,7 @@ The MCP server (`src/mind/interfaces/mcp/`) provides network access to minds via
 
 **Tools:**
 - `create_mind(mind_id, config)`: Initialize mind with cognitive pipeline
-- `decide_action(mind_id, observation)`: Process structured observation → action dict
+- `decide_action(mind_id, observation, events)`: Process structured observation + events → action dict
 - `consolidate_memories(mind_id)`: Transfer daily → long-term storage
 - `cleanup_mind(mind_id)`: Remove mind and free resources
 

--- a/mind/docs/interfaces/mcp.md
+++ b/mind/docs/interfaces/mcp.md
@@ -38,7 +38,7 @@ Encapsulates a single mind's state and cognitive pipeline.
 - Tracks conversation histories per interaction
 - Manages event buffer with retention policy (60 game minutes OR max 15 events)
 
-**Configuration:** Initialized via `Mind.from_config(mind_id, config)` with `MindConfig` specifying entity ID, personality traits, LLM model, and memory storage path.
+**Configuration:** Initialized via `Mind.from_config(mind_id, entity_id, config)`. `mind_id` (PK) keys the mind and its memory collection; `entity_id` (FK) names the simulation entity the mind drives; `MindConfig` carries the cognition-only settings (personality traits, LLM model, memory storage path). `entity_id` is no longer a `MindConfig` field.
 
 ## MCP Tools
 
@@ -46,7 +46,7 @@ The server exposes four RPC methods for mind lifecycle and decision-making.
 
 ### create_mind
 
-Creates a new mind instance with specified configuration. Takes `mind_id` and `MindConfig` (entity ID, traits, LLM model, memory storage path, optional seed memories).
+Creates a new mind instance. Takes `mind_id` (PK), `entity_id` (FK), and `MindConfig` as separate arguments. `mind_id` keys the mind and its memory collection; `entity_id` names the simulation entity the mind drives; `MindConfig` holds cognition-only settings (traits, LLM model, memory storage path, optional seed memories). `entity_id` is no longer a `MindConfig` field.
 
 ### decide_action
 

--- a/mind/src/mind/interfaces/mcp/mind.py
+++ b/mind/src/mind/interfaces/mcp/mind.py
@@ -39,12 +39,14 @@ class Mind:
     pending_incoming_bids: dict[str, MindEvent] = field(default_factory=dict)
 
     @classmethod
-    def from_config(cls, mind_id: str, config) -> Self:
+    def from_config(cls, mind_id: str, entity_id: str, config) -> Self:
         """Create a Mind instance from configuration
 
         Args:
-            mind_id: Unique identifier for the mind
-            config: MindConfig with LLM, memory, and initial state settings
+            mind_id: The mind's own identifier (PK) - keys the memory collection
+            entity_id: The simulation entity this mind drives (FK) - deliberately
+                independent of mind_id; carried for per-NPC log attribution
+            config: MindConfig with traits, LLM, memory, and personality settings
 
         Returns:
             Initialized Mind instance
@@ -52,7 +54,7 @@ class Mind:
         # Initialize LLM from config
         llm = get_llm(config.llm_model)
 
-        # Initialize memory store with configured collection name
+        # Memory belongs to the mind, so the collection is keyed by the mind PK
         memory_store = VectorDBMemory(
             collection_name=f"mind_{mind_id}",
             embedding_model=config.embedding_model,
@@ -72,7 +74,7 @@ class Mind:
         # Create Mind instance
         return cls(
             mind_id=mind_id,
-            entity_id=config.entity_id,
+            entity_id=entity_id,
             traits=config.traits,
             personality_dimensions=config.personality_dimensions,
             pipeline=pipeline,
@@ -128,23 +130,24 @@ class Mind:
                     self.pending_incoming_bids[bid_id] = event
 
             elif event.event_type == MindEventType.ERROR:
-                # Log error events for debugging
+                # Log error events for debugging. Per-NPC line: attribute to the entity FK
+                # so the sim /logs forwarder routes it to the NPC's Events tab.
                 message = event.payload.get("message", "Unknown error")
-                logger.warning(f"[{self.mind_id}] Received error event: {message}")
+                logger.warning(f"[{self.entity_id}] Received error event: {message}")
 
             elif event.event_type == MindEventType.INTERACTION_BID_CANCELED:
                 # Remove canceled bid from pending list
                 bid_id = event.payload.get("bid_id")
                 if bid_id and bid_id in self.pending_incoming_bids:
                     del self.pending_incoming_bids[bid_id]
-                    logger.debug(f"[{self.mind_id}] Removed canceled bid {bid_id} from pending bids")
+                    logger.debug(f"[{self.entity_id}] Removed canceled bid {bid_id} from pending bids")
 
             elif event.event_type in (MindEventType.INTERACTION_FINISHED, MindEventType.INTERACTION_CANCELED):
                 # Clean up conversation history for ended interactions
                 interaction_id = event.payload.get("interaction_id")
                 if interaction_id and interaction_id in self.conversation_histories:
                     del self.conversation_histories[interaction_id]
-                    logger.debug(f"[{self.mind_id}] Cleaned up conversation history for {interaction_id}")
+                    logger.debug(f"[{self.entity_id}] Cleaned up conversation history for {interaction_id}")
 
         self.event_buffer.extend(new_events)
 

--- a/mind/src/mind/interfaces/mcp/mind.py
+++ b/mind/src/mind/interfaces/mcp/mind.py
@@ -9,6 +9,7 @@ from mind.cognitive_architecture.observations import ConversationMessage, MindEv
 from mind.cognitive_architecture.nodes.cognitive_update.models import NewMemory, WorkingMemory
 from mind.cognitive_architecture.pipeline import CognitivePipeline
 from mind.logging_config import get_logger
+from mind.interfaces.mcp.models import MindConfig
 
 logger = get_logger()
 
@@ -39,7 +40,7 @@ class Mind:
     pending_incoming_bids: dict[str, MindEvent] = field(default_factory=dict)
 
     @classmethod
-    def from_config(cls, mind_id: str, entity_id: str, config) -> Self:
+    def from_config(cls, mind_id: str, entity_id: str, config: MindConfig) -> Self:
         """Create a Mind instance from configuration
 
         Args:

--- a/mind/src/mind/interfaces/mcp/models.py
+++ b/mind/src/mind/interfaces/mcp/models.py
@@ -13,9 +13,13 @@ from mind.cognitive_architecture.nodes.cognitive_update.models import WorkingMem
 
 
 class MindConfig(BaseModel):
-    """Configuration for creating a new mind - everything should be configurable"""
+    """Configuration for creating a new mind - traits, LLM, memory, personality only.
 
-    entity_id: str  # Mind's entity ID in simulation
+    The driven entity (entity_id FK) is a top-level create_mind argument, not config:
+    config is pure cognitive configuration, deliberately independent of which entity
+    the mind drives.
+    """
+
     traits: list[str]
 
     # LLM configuration
@@ -39,7 +43,7 @@ class MindConfig(BaseModel):
 class SimulationRequest(BaseModel):
     """Request from simulation to mind for action decision"""
 
-    mind_id: str  # MCP routing (matches entity_id typically)
+    mind_id: str  # MCP routing key (PK); deliberately independent of the driven entity_id
     observation: Observation  # Structured observation
 
 
@@ -76,5 +80,6 @@ class MindInfoResponse(BaseModel):
     """Create/cleanup result"""
 
     status: str
-    mind_id: str
+    mind_id: str  # PK: the mind's own identifier
+    entity_id: str | None = None  # FK: the driven entity (None for lifecycle ops like cleanup)
     message: str | None = None

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -182,9 +182,18 @@ class MCPServer:
         ) -> dict:
             """Process observation from simulation and decide on an action
 
+            mind_id is the routing primary key: it selects which mind in self.minds
+            handles this request and keys that mind's memory collection. It is distinct
+            from the entity_id foreign key carried inside the observation, which names
+            the simulation entity the mind drives. In correct operation the two agree
+            (the routed mind drives that entity); a divergence is logged as a possible
+            misrouting (see the mismatch warning below) but does not reject the request.
+
             Args:
-                mind_id: Unique identifier for the mind
-                observation: Structured observation dict (will be validated to Observation model)
+                mind_id: Routing primary key (PK) selecting the mind; distinct from the
+                    observation entity_id foreign key (FK).
+                observation: Structured observation dict (will be validated to Observation
+                    model); carries the entity_id FK the pipeline attributes work to.
                 events: List of mind events
 
             Returns:
@@ -223,6 +232,18 @@ class MCPServer:
                             f"Invalid event format: {str(e)}",
                             details=str(e)
                         )
+
+                # Defensive misrouting check: mind_id (PK) routes the request while the
+                # observation carries its own entity_id (FK). In correct operation these
+                # agree (the mind drives that entity); a divergence means the observation
+                # was routed to the wrong mind. Warn (with both ids) so it is diagnosable,
+                # but do not reject - the pipeline keeps using the observation's entity_id.
+                if obs.entity_id != mind.entity_id:
+                    logger.warning(
+                        f"[{request_id}] entity_id mismatch for mind {mind_id}: "
+                        f"observation entity_id={obs.entity_id} but mind entity_id={mind.entity_id} "
+                        f"(possible misrouting; using observation entity_id for the pipeline)"
+                    )
 
                 # Extract conversation observations from INTERACTION_OBSERVATION events.
                 # Pass the entity FK so per-NPC log lines attribute to the NPC's Events tab.
@@ -317,10 +338,15 @@ class MCPServer:
             Args:
                 mind_id: Mind to remove
             """
+            # The mind is still registered here, so its entity_id (FK) is available;
+            # surface it in the response so cleanup is symmetric with create_mind.
+            # (The Godot client ignores this optional field, so this is non-breaking.)
+            entity_id = None
             if mind_id in self.minds:
+                entity_id = self.minds[mind_id].entity_id
                 del self.minds[mind_id]
 
-            return MindInfoResponse(status="removed", mind_id=mind_id)
+            return MindInfoResponse(status="removed", mind_id=mind_id, entity_id=entity_id)
 
         # === Resources ===
 

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -186,8 +186,9 @@ class MCPServer:
             handles this request and keys that mind's memory collection. It is distinct
             from the entity_id foreign key carried inside the observation, which names
             the simulation entity the mind drives. In correct operation the two agree
-            (the routed mind drives that entity); a divergence is logged as a possible
-            misrouting (see the mismatch warning below) but does not reject the request.
+            (the routed mind drives that entity); a divergence is logged (both ids) and
+            the request is rejected, since a decision on a misrouted observation would
+            be garbage.
 
             Args:
                 mind_id: Routing primary key (PK) selecting the mind; distinct from the
@@ -236,9 +237,9 @@ class MCPServer:
                 # Defensive misrouting check: mind_id (PK) routes the request while the
                 # observation carries its own entity_id (FK). In correct operation these
                 # agree (the mind drives that entity); a divergence means the observation
-                # was routed to the wrong mind. Warn (with both ids) so it is diagnosable,
-                # was routed to the wrong mind. Fail loud at the boundary (a decision
-                # computed on a misrouted observation would be garbage): log and reject.
+                # was routed to the wrong mind. Fail loud at the boundary - log both ids
+                # (so misrouting stays diagnosable) and reject, since a decision computed
+                # on a misrouted observation would be garbage.
                 if obs.entity_id != mind.entity_id:
                     logger.warning(
                         f"[{request_id}] entity_id mismatch for mind {mind_id}: "

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -53,15 +53,15 @@ def _success_response(request_id: str, action: dict) -> dict:
 
 
 def _extract_conversation_observations(
-    events: list[MindEvent], mind_id: str
+    events: list[MindEvent], entity_id: str
 ) -> list[ConversationObservation]:
     """Extract conversation observations from INTERACTION_OBSERVATION events.
 
     Args:
         events: List of MindEvent objects
-        mind_id: Mind these events belong to (for per-NPC log attribution; must carry the
-            entity-id shape the sim /logs forwarder matches — it does,
-            mind_id == entity_id per models.py)
+        entity_id: Driven entity FK these events belong to. This is a per-NPC log line,
+            so it carries entity_id (not the mind PK): the sim /logs forwarder
+            regex-attributes the tag to the NPC's Events tab.
 
     Returns:
         List of ConversationObservation objects parsed from interaction observation events
@@ -75,21 +75,21 @@ def _extract_conversation_observations(
                 conversations.append(conv_obs)
             except ValidationError as e:
                 # Not a conversation observation or malformed - skip it
-                logger.debug(f"[{mind_id}] Skipping non-conversation interaction observation: {e}")
+                logger.debug(f"[{entity_id}] Skipping non-conversation interaction observation: {e}")
                 continue
     return conversations
 
 
-def _cleanup_responded_bids(action, pending_bids: dict, request_id: str, mind_id: str) -> None:
+def _cleanup_responded_bids(action, pending_bids: dict, request_id: str, entity_id: str) -> None:
     """Remove bids from pending list after responding to them.
 
     Args:
         action: The chosen action (Action model)
         pending_bids: Dict of pending incoming bids (modified in place)
-        request_id: Request ID for logging
-        mind_id: Mind the bids belong to (for per-NPC log attribution; must carry the
-            entity-id shape the sim /logs forwarder matches — it does,
-            mind_id == entity_id per models.py)
+        request_id: Server-routing correlation id (not NPC-attributed)
+        entity_id: Driven entity FK the bids belong to. These are per-NPC log lines,
+            so they carry entity_id (not the mind PK): the sim /logs forwarder
+            regex-attributes the tag to the NPC's Events tab.
     """
     if not action:
         return
@@ -99,7 +99,7 @@ def _cleanup_responded_bids(action, pending_bids: dict, request_id: str, mind_id
         bid_id = action.parameters.get("bid_id")
         if bid_id and bid_id in pending_bids:
             pending_bids.pop(bid_id)
-            logger.debug(f"[{request_id}] [{mind_id}] Removed bid {bid_id} from pending bids after response")
+            logger.debug(f"[{request_id}] [{entity_id}] Removed bid {bid_id} from pending bids after response")
 
     elif action.action == ActionType.BATCH_REJECT_INTERACTION_BIDS:
         # Batch bid rejection
@@ -128,7 +128,7 @@ def _cleanup_responded_bids(action, pending_bids: dict, request_id: str, mind_id
         for bid_id in bid_ids_to_remove:
             pending_bids.pop(bid_id, None)
 
-        logger.debug(f"[{request_id}] [{mind_id}] Batch rejected {len(bid_ids_to_remove)} bids: {bid_ids_to_remove}")
+        logger.debug(f"[{request_id}] [{entity_id}] Batch rejected {len(bid_ids_to_remove)} bids: {bid_ids_to_remove}")
 
 
 class MCPServer:
@@ -151,19 +151,27 @@ class MCPServer:
         @self.mcp.tool()
         async def create_mind(
             mind_id: str,
+            entity_id: str,
             config: MindConfig,
             ctx: Context = None,
         ) -> MindInfoResponse:
             """Create a new NPC mind
 
+            mind_id (PK) and entity_id (FK) are deliberately distinct first-class ids:
+            the mind owns its memory under the PK; the FK names the simulation entity
+            the mind drives and is what per-NPC logs attribute to.
+
             Args:
-                mind_id: Unique identifier for the mind (usually matches entity_id)
-                config: Configuration with entity_id, traits, LLM settings, memory settings, initial state
+                mind_id: The mind's own identifier (PK). Keys self.minds and the
+                    memory collection.
+                entity_id: The simulation entity this mind drives (FK).
+                config: Cognitive configuration - traits, LLM settings, memory
+                    settings, personality dimensions, initial state.
             """
-            mind = Mind.from_config(mind_id, config)
+            mind = Mind.from_config(mind_id, entity_id, config)
             self.minds[mind_id] = mind
 
-            return MindInfoResponse(status="created", mind_id=mind_id)
+            return MindInfoResponse(status="created", mind_id=mind_id, entity_id=entity_id)
 
         @self.mcp.tool()
         async def decide_action(
@@ -216,8 +224,9 @@ class MCPServer:
                             details=str(e)
                         )
 
-                # Extract conversation observations from INTERACTION_OBSERVATION events
-                conversation_obs = _extract_conversation_observations(mind_events, mind_id)
+                # Extract conversation observations from INTERACTION_OBSERVATION events.
+                # Pass the entity FK so per-NPC log lines attribute to the NPC's Events tab.
+                conversation_obs = _extract_conversation_observations(mind_events, mind.entity_id)
                 mind.update_conversations(conversation_obs)
                 mind.update_events(mind_events, obs.current_simulation_time)
 
@@ -240,8 +249,11 @@ class MCPServer:
                 mind.daily_memories.extend(result.daily_memories)
                 mind.event_buffer = result.recent_events
 
-                # Clean up any bids that were responded to
-                _cleanup_responded_bids(result.chosen_action, mind.pending_incoming_bids, request_id, mind_id)
+                # Clean up any bids that were responded to. Pass the entity FK so the
+                # per-NPC bid-cleanup log lines attribute to the NPC's Events tab.
+                _cleanup_responded_bids(
+                    result.chosen_action, mind.pending_incoming_bids, request_id, mind.entity_id
+                )
 
                 if result.chosen_action is None:
                     logger.warning(f"[{request_id}] Pipeline returned no action for {mind_id}")

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -237,12 +237,18 @@ class MCPServer:
                 # observation carries its own entity_id (FK). In correct operation these
                 # agree (the mind drives that entity); a divergence means the observation
                 # was routed to the wrong mind. Warn (with both ids) so it is diagnosable,
-                # but do not reject - the pipeline keeps using the observation's entity_id.
+                # was routed to the wrong mind. Fail loud at the boundary (a decision
+                # computed on a misrouted observation would be garbage): log and reject.
                 if obs.entity_id != mind.entity_id:
                     logger.warning(
                         f"[{request_id}] entity_id mismatch for mind {mind_id}: "
                         f"observation entity_id={obs.entity_id} but mind entity_id={mind.entity_id} "
-                        f"(possible misrouting; using observation entity_id for the pipeline)"
+                        f"(misrouting — rejecting the request)"
+                    )
+                    return _error_response(
+                        request_id,
+                        f"entity_id mismatch: observation '{obs.entity_id}' "
+                        f"but mind drives '{mind.entity_id}'",
                     )
 
                 # Extract conversation observations from INTERACTION_OBSERVATION events.

--- a/mind/tests/fixtures/observations.py
+++ b/mind/tests/fixtures/observations.py
@@ -306,9 +306,8 @@ def create_emergency_observation(simulation_time: int = 100) -> Observation:
 
 
 def create_blacksmith_config() -> MindConfig:
-    """Configuration for a blacksmith NPC mind"""
+    """Configuration for a blacksmith NPC mind (entity_id is a create_mind arg, not config)"""
     return MindConfig(
-        entity_id="blacksmith_npc",
         traits=["diligent", "perfectionist", "proud", "helpful"],
         llm_model=DEFAULT_SMALL_MODEL,
         embedding_model=DEFAULT_EMBEDDING_MODEL,
@@ -328,9 +327,8 @@ def create_blacksmith_config() -> MindConfig:
 
 
 def create_explorer_config() -> MindConfig:
-    """Configuration for an explorer NPC mind"""
+    """Configuration for an explorer NPC mind (entity_id is a create_mind arg, not config)"""
     return MindConfig(
-        entity_id="explorer_npc",
         traits=["curious", "brave", "resourceful", "independent"],
         llm_model=DEFAULT_SMALL_MODEL,
         embedding_model=DEFAULT_EMBEDDING_MODEL,

--- a/mind/tests/integration/test_mcp_server.py
+++ b/mind/tests/integration/test_mcp_server.py
@@ -22,11 +22,16 @@ def mcp_server():
     return MCPServer("Test Mind Server")
 
 
+# mind_id (PK) and entity_id (FK) are deliberately DIFFERENT here so every test
+# proves the decouple rather than relying on them being the same string.
+TEST_MIND_ID = "mind_abc"
+TEST_ENTITY_ID = "entity_xyz"
+
+
 @pytest.fixture
 def test_mind_config():
-    """Create a test mind configuration"""
+    """Create a test mind configuration (no entity_id - that is a create_mind arg)"""
     return MindConfig(
-        entity_id="test_npc_001",
         traits=["curious", "brave"],
         personality_dimensions={
             "extroversion": 0.7,
@@ -94,24 +99,44 @@ def test_observation():
 
 @pytest.mark.asyncio
 async def test_create_mind(mcp_server, test_mind_config):
-    """Test creating a new mind"""
+    """Test creating a new mind - mind_id (PK) and entity_id (FK) flow independently"""
+    assert TEST_MIND_ID != TEST_ENTITY_ID  # guard: the fixtures must actually differ
+
     result = await mcp_server.mcp.call_tool(
-        "create_mind", {"mind_id": "test_mind_001", "config": test_mind_config.model_dump()}
+        "create_mind",
+        {
+            "mind_id": TEST_MIND_ID,
+            "entity_id": TEST_ENTITY_ID,
+            "config": test_mind_config.model_dump(),
+        },
     )
 
     # Parse response from TextContent list
     response = json.loads(result[0].text)
 
     assert response["status"] == "created"
-    assert response["mind_id"] == "test_mind_001"
-    assert "test_mind_001" in mcp_server.minds
+    # Response carries BOTH ids, distinct
+    assert response["mind_id"] == TEST_MIND_ID
+    assert response["entity_id"] == TEST_ENTITY_ID
+    # Registry is keyed by the mind PK, not the entity FK
+    assert TEST_MIND_ID in mcp_server.minds
+    assert TEST_ENTITY_ID not in mcp_server.minds
+    # The stored Mind carries the entity FK exactly as supplied
+    assert mcp_server.minds[TEST_MIND_ID].entity_id == TEST_ENTITY_ID
+    # Memory collection is keyed by the mind PK
+    assert mcp_server.minds[TEST_MIND_ID].memory_store.collection.name == f"mind_{TEST_MIND_ID}"
 
 
 @pytest.mark.asyncio
 async def test_create_mind_stores_personality_dimensions(mcp_server, test_mind_config):
     """Personality dimensions in config should round-trip into the stored Mind"""
     await mcp_server.mcp.call_tool(
-        "create_mind", {"mind_id": "test_mind_dims", "config": test_mind_config.model_dump()}
+        "create_mind",
+        {
+            "mind_id": "test_mind_dims",
+            "entity_id": "entity_dims",
+            "config": test_mind_config.model_dump(),
+        },
     )
 
     mind = mcp_server.minds["test_mind_dims"]
@@ -127,12 +152,16 @@ async def test_create_mind_stores_personality_dimensions(mcp_server, test_mind_c
 async def test_create_mind_without_personality_dimensions_defaults_to_empty(mcp_server):
     """Configs that omit personality_dimensions should default to an empty dict"""
     minimal_config = MindConfig(
-        entity_id="minimal_npc",
         traits=["plain"],
     )
 
     await mcp_server.mcp.call_tool(
-        "create_mind", {"mind_id": "test_mind_minimal", "config": minimal_config.model_dump()}
+        "create_mind",
+        {
+            "mind_id": "test_mind_minimal",
+            "entity_id": "entity_minimal",
+            "config": minimal_config.model_dump(),
+        },
     )
 
     mind = mcp_server.minds["test_mind_minimal"]
@@ -141,13 +170,18 @@ async def test_create_mind_without_personality_dimensions_defaults_to_empty(mcp_
 
 @pytest.mark.asyncio
 async def test_decide_action(mcp_server, test_mind_config, test_observation):
-    """Test deciding an action based on observation"""
-    # Create mind
+    """Test deciding an action based on observation - routing keys on the mind PK"""
+    # Create mind: PK and FK are distinct
     await mcp_server.mcp.call_tool(
-        "create_mind", {"mind_id": "test_mind_001", "config": test_mind_config.model_dump()}
+        "create_mind",
+        {
+            "mind_id": "test_mind_001",
+            "entity_id": "test_npc_001",
+            "config": test_mind_config.model_dump(),
+        },
     )
 
-    # Decide action using new structured format
+    # decide_action routes by the mind PK, not the entity FK
     result = await mcp_server.mcp.call_tool(
         "decide_action", {"mind_id": "test_mind_001", "observation": test_observation.model_dump()}
     )
@@ -162,10 +196,15 @@ async def test_decide_action(mcp_server, test_mind_config, test_observation):
 
 @pytest.mark.asyncio
 async def test_consolidate_memories(mcp_server, test_mind_config):
-    """Test memory consolidation"""
-    # Create mind
+    """Test memory consolidation - routes by the mind PK"""
+    # Create mind: PK and FK are distinct
     await mcp_server.mcp.call_tool(
-        "create_mind", {"mind_id": "test_mind_001", "config": test_mind_config.model_dump()}
+        "create_mind",
+        {
+            "mind_id": "test_mind_001",
+            "entity_id": "test_npc_001",
+            "config": test_mind_config.model_dump(),
+        },
     )
 
     # Manually add some daily memories for testing
@@ -187,33 +226,45 @@ async def test_consolidate_memories(mcp_server, test_mind_config):
 
 @pytest.mark.asyncio
 async def test_cleanup_mind(mcp_server, test_mind_config):
-    """Test mind cleanup"""
-    # Create mind
+    """Test mind cleanup - routes by the mind PK"""
+    # Create mind: PK and FK are distinct
     await mcp_server.mcp.call_tool(
-        "create_mind", {"mind_id": "test_mind_001", "config": test_mind_config.model_dump()}
+        "create_mind",
+        {
+            "mind_id": "test_mind_001",
+            "entity_id": "test_npc_001",
+            "config": test_mind_config.model_dump(),
+        },
     )
 
     assert "test_mind_001" in mcp_server.minds
 
-    # Cleanup
+    # Cleanup routes by the mind PK
     result = await mcp_server.mcp.call_tool("cleanup_mind", {"mind_id": "test_mind_001"})
 
     # Parse response from TextContent list
     response = json.loads(result[0].text)
 
     assert response["status"] == "removed"
+    assert response["mind_id"] == "test_mind_001"
     assert "test_mind_001" not in mcp_server.minds
 
 
 @pytest.mark.asyncio
 async def test_full_workflow(mcp_server, test_mind_config, test_observation):
     """Test complete workflow: create, decide, consolidate, cleanup"""
-    # Step 1: Create mind
+    # Step 1: Create mind (PK and FK distinct)
     result = await mcp_server.mcp.call_tool(
-        "create_mind", {"mind_id": "test_mind_001", "config": test_mind_config.model_dump()}
+        "create_mind",
+        {
+            "mind_id": "test_mind_001",
+            "entity_id": "test_npc_001",
+            "config": test_mind_config.model_dump(),
+        },
     )
     create_response = json.loads(result[0].text)
     assert create_response["status"] == "created"
+    assert create_response["entity_id"] == "test_npc_001"
 
     # Step 2: Make a decision
     result = await mcp_server.mcp.call_tool(

--- a/mind/tests/unit/test_mcp_server.py
+++ b/mind/tests/unit/test_mcp_server.py
@@ -27,7 +27,7 @@ class TestMCPServerErrorHandling:
             {
                 "mind_id": "nonexistent",
                 "observation": {
-                    "entity_id": "test",
+                    "entity_id": "entity_test",
                     "current_simulation_time": 0,
                 },
             },
@@ -62,7 +62,7 @@ class TestMCPServerErrorHandling:
             "decide_action",
             {
                 "mind_id": "mind_test",
-                "observation": {"entity_id": "test"},
+                "observation": {"entity_id": "entity_test"},
             },
         )
 
@@ -100,7 +100,7 @@ class TestMCPServerErrorHandling:
             {
                 "mind_id": "mind_test",
                 "observation": {
-                    "entity_id": "test",
+                    "entity_id": "entity_test",
                     "current_simulation_time": "not_an_int",
                 },
             },
@@ -139,7 +139,7 @@ class TestMCPServerErrorHandling:
             {
                 "mind_id": "mind_test",
                 "observation": {
-                    "entity_id": "test",
+                    "entity_id": "entity_test",
                     "current_simulation_time": 100,
                     "vision": {},
                 },
@@ -179,7 +179,7 @@ class TestMCPServerErrorHandling:
             {
                 "mind_id": "mind_test",
                 "observation": {
-                    "entity_id": "test",
+                    "entity_id": "entity_test",
                     "current_simulation_time": "invalid",
                 },
             },
@@ -213,7 +213,7 @@ class TestMCPServerErrorHandling:
         )
 
         observation = {
-            "entity_id": "test",
+            "entity_id": "entity_test",
             "current_simulation_time": 100,
             "status": {
                 "position": [5, 5],
@@ -301,7 +301,7 @@ class TestMCPServerErrorHandling:
         )
 
         observation = {
-            "entity_id": "test",
+            "entity_id": "entity_test",
             "current_simulation_time": 100,
             "status": {
                 "position": [5, 5],
@@ -395,7 +395,7 @@ class TestMCPServerErrorHandling:
         )
 
         observation = {
-            "entity_id": "test",
+            "entity_id": "entity_test",
             "current_simulation_time": 100,
             "status": {
                 "position": [5, 5],
@@ -523,3 +523,85 @@ class TestCreateMindDecouplesIds:
         assert mind.entity_id == "entity_xyz"
         # Memory collection keyed by the mind PK
         assert mind.memory_store.collection.name == "mind_mind_abc"
+
+
+class TestDecideActionEntityIdMismatch:
+    """decide_action warns (does not reject) when the observation entity_id (FK)
+    diverges from the routed mind entity_id, so misrouting is diagnosable (NPC-795)."""
+
+    @staticmethod
+    async def _run_decide(server, observation):
+        """Create a mind (entity_test) with a stubbed pipeline, run decide_action."""
+        from mind.cognitive_architecture.actions import Action
+        from mind.cognitive_architecture.state import PipelineState
+
+        await server.mcp.call_tool(
+            "create_mind",
+            {
+                "mind_id": "mind_test",
+                "entity_id": "entity_test",
+                "config": {
+                    "traits": [],
+                    "initial_long_term_memories": [],
+                },
+            },
+        )
+
+        mind = server.minds["mind_test"]
+
+        async def mock_process(state: PipelineState) -> PipelineState:
+            state.chosen_action = Action.model_construct(action="wait", parameters={})
+            return state
+
+        mind.pipeline.process = mock_process
+
+        return await server.mcp.call_tool(
+            "decide_action",
+            {
+                "mind_id": "mind_test",
+                "observation": observation,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_warns_when_observation_entity_id_differs_from_mind(self, caplog):
+        import logging
+
+        server = MCPServer()
+        observation = {
+            "entity_id": "entity_other",
+            "current_simulation_time": 100,
+        }
+
+        with caplog.at_level(logging.WARNING):
+            result = await self._run_decide(server, observation)
+
+        response = parse_response(result)
+        assert response["status"] == "success"
+
+        mismatch_lines = [
+            r.getMessage() for r in caplog.records if "entity_id mismatch" in r.getMessage()
+        ]
+        assert mismatch_lines, "expected an entity_id mismatch warning"
+        assert any("entity_other" in line and "entity_test" in line for line in mismatch_lines)
+
+    @pytest.mark.asyncio
+    async def test_silent_when_observation_entity_id_matches_mind(self, caplog):
+        import logging
+
+        server = MCPServer()
+        observation = {
+            "entity_id": "entity_test",
+            "current_simulation_time": 100,
+        }
+
+        with caplog.at_level(logging.WARNING):
+            result = await self._run_decide(server, observation)
+
+        response = parse_response(result)
+        assert response["status"] == "success"
+
+        mismatch_lines = [
+            r.getMessage() for r in caplog.records if "entity_id mismatch" in r.getMessage()
+        ]
+        assert not mismatch_lines, "no mismatch warning expected when ids agree"

--- a/mind/tests/unit/test_mcp_server.py
+++ b/mind/tests/unit/test_mcp_server.py
@@ -49,9 +49,9 @@ class TestMCPServerErrorHandling:
         await server.mcp.call_tool(
             "create_mind",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
+                "entity_id": "entity_test",
                 "config": {
-                    "entity_id": "test",
                     "traits": [],
                     "initial_long_term_memories": [],
                 },
@@ -61,7 +61,7 @@ class TestMCPServerErrorHandling:
         result = await server.mcp.call_tool(
             "decide_action",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
                 "observation": {"entity_id": "test"},
             },
         )
@@ -86,9 +86,9 @@ class TestMCPServerErrorHandling:
         await server.mcp.call_tool(
             "create_mind",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
+                "entity_id": "entity_test",
                 "config": {
-                    "entity_id": "test",
                     "traits": [],
                     "initial_long_term_memories": [],
                 },
@@ -98,7 +98,7 @@ class TestMCPServerErrorHandling:
         result = await server.mcp.call_tool(
             "decide_action",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
                 "observation": {
                     "entity_id": "test",
                     "current_simulation_time": "not_an_int",
@@ -125,9 +125,9 @@ class TestMCPServerErrorHandling:
         await server.mcp.call_tool(
             "create_mind",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
+                "entity_id": "entity_test",
                 "config": {
-                    "entity_id": "test",
                     "traits": [],
                     "initial_long_term_memories": [],
                 },
@@ -137,7 +137,7 @@ class TestMCPServerErrorHandling:
         result = await server.mcp.call_tool(
             "decide_action",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
                 "observation": {
                     "entity_id": "test",
                     "current_simulation_time": 100,
@@ -165,9 +165,9 @@ class TestMCPServerErrorHandling:
         await server.mcp.call_tool(
             "create_mind",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
+                "entity_id": "entity_test",
                 "config": {
-                    "entity_id": "test",
                     "traits": [],
                     "initial_long_term_memories": [],
                 },
@@ -177,7 +177,7 @@ class TestMCPServerErrorHandling:
         result = await server.mcp.call_tool(
             "decide_action",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
                 "observation": {
                     "entity_id": "test",
                     "current_simulation_time": "invalid",
@@ -203,9 +203,9 @@ class TestMCPServerErrorHandling:
         await server.mcp.call_tool(
             "create_mind",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
+                "entity_id": "entity_test",
                 "config": {
-                    "entity_id": "test",
                     "traits": ["curious"],
                     "initial_long_term_memories": [],
                 },
@@ -239,7 +239,7 @@ class TestMCPServerErrorHandling:
         }
 
         # Mock the pipeline to return a successful action
-        mind = server.minds["test"]
+        mind = server.minds["mind_test"]
         original_process = mind.pipeline.process
 
         async def mock_process(state: PipelineState) -> PipelineState:
@@ -251,7 +251,7 @@ class TestMCPServerErrorHandling:
         result = await server.mcp.call_tool(
             "decide_action",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
                 "observation": observation,
             },
         )
@@ -273,8 +273,15 @@ class TestMCPServerErrorHandling:
             assert "parameters" in response["action"]
 
     @pytest.mark.asyncio
-    async def test_bid_cleanup_after_response(self):
-        """Should remove bid from pending_incoming_bids after responding"""
+    async def test_bid_cleanup_after_response(self, caplog):
+        """Should remove bid from pending_incoming_bids after responding.
+
+        Also asserts the attribution decouple: the bid-cleanup log line carries the
+        entity FK (entity_test), not the mind PK (mind_test), so the sim /logs
+        forwarder routes it to the NPC's Events tab.
+        """
+        import logging
+
         from mind.cognitive_architecture.actions import Action, ActionType
         from mind.cognitive_architecture.observations import MindEvent, MindEventType
         from mind.cognitive_architecture.state import PipelineState
@@ -284,9 +291,9 @@ class TestMCPServerErrorHandling:
         await server.mcp.call_tool(
             "create_mind",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
+                "entity_id": "entity_test",
                 "config": {
-                    "entity_id": "test",
                     "traits": ["friendly"],
                     "initial_long_term_memories": [],
                 },
@@ -317,7 +324,7 @@ class TestMCPServerErrorHandling:
         }
 
         # Mock the pipeline to return a bid response action
-        mind = server.minds["test"]
+        mind = server.minds["mind_test"]
         original_process = mind.pipeline.process
 
         async def mock_process(state: PipelineState) -> PipelineState:
@@ -334,14 +341,15 @@ class TestMCPServerErrorHandling:
         mind.pipeline.process = mock_process
 
         # Verify bid is stored before response
-        result = await server.mcp.call_tool(
-            "decide_action",
-            {
-                "mind_id": "test",
-                "observation": observation,
-                "events": [bid_event],
-            },
-        )
+        with caplog.at_level(logging.DEBUG):
+            result = await server.mcp.call_tool(
+                "decide_action",
+                {
+                    "mind_id": "mind_test",
+                    "observation": observation,
+                    "events": [bid_event],
+                },
+            )
 
         # Restore original
         mind.pipeline.process = original_process
@@ -355,6 +363,16 @@ class TestMCPServerErrorHandling:
         # Verify bid was removed from pending_incoming_bids
         assert "bid_test_123" not in mind.pending_incoming_bids
 
+        # Attribution decouple: the bid-cleanup line is tagged with the entity FK,
+        # never the mind PK, so it lands on the NPC's Events tab.
+        cleanup_lines = [
+            r.getMessage() for r in caplog.records if "Removed bid bid_test_123" in r.getMessage()
+        ]
+        assert cleanup_lines, "expected a bid-cleanup log line"
+        for line in cleanup_lines:
+            assert "[entity_test]" in line
+            assert "[mind_test]" not in line
+
     @pytest.mark.asyncio
     async def test_bid_cleanup_only_for_bid_response_actions(self):
         """Should not affect pending_incoming_bids for non-bid actions"""
@@ -367,9 +385,9 @@ class TestMCPServerErrorHandling:
         await server.mcp.call_tool(
             "create_mind",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
+                "entity_id": "entity_test",
                 "config": {
-                    "entity_id": "test",
                     "traits": ["friendly"],
                     "initial_long_term_memories": [],
                 },
@@ -400,7 +418,7 @@ class TestMCPServerErrorHandling:
         }
 
         # Mock the pipeline to return a non-bid action (e.g., wait)
-        mind = server.minds["test"]
+        mind = server.minds["mind_test"]
         original_process = mind.pipeline.process
 
         async def mock_process(state: PipelineState) -> PipelineState:
@@ -415,7 +433,7 @@ class TestMCPServerErrorHandling:
         result = await server.mcp.call_tool(
             "decide_action",
             {
-                "mind_id": "test",
+                "mind_id": "mind_test",
                 "observation": observation,
                 "events": [bid_event],
             },
@@ -442,7 +460,6 @@ class TestMindConfigValidation:
         from mind.interfaces.mcp.models import MindConfig
         with pytest.raises(ValidationError):
             MindConfig(
-                entity_id="npc_test",
                 traits=["curious"],
                 personality_dimensions={"extroversion": 1.5},
             )
@@ -452,7 +469,6 @@ class TestMindConfigValidation:
         from mind.interfaces.mcp.models import MindConfig
         with pytest.raises(ValidationError):
             MindConfig(
-                entity_id="npc_test",
                 traits=["curious"],
                 personality_dimensions={"curiosity": -0.1},
             )
@@ -460,7 +476,6 @@ class TestMindConfigValidation:
     def test_accepts_in_range_values(self):
         from mind.interfaces.mcp.models import MindConfig
         config = MindConfig(
-            entity_id="npc_test",
             traits=["curious"],
             personality_dimensions={
                 "extroversion": 0.0,
@@ -471,3 +486,40 @@ class TestMindConfigValidation:
         assert config.personality_dimensions["extroversion"] == 0.0
         assert config.personality_dimensions["curiosity"] == 0.5
         assert config.personality_dimensions["sensitivity"] == 1.0
+
+    def test_config_has_no_entity_id_field(self):
+        """entity_id is a create_mind arg (FK), not config: config is pure cognition."""
+        from mind.interfaces.mcp.models import MindConfig
+        assert "entity_id" not in MindConfig.model_fields
+
+
+class TestCreateMindDecouplesIds:
+    """create_mind treats mind_id (PK) and entity_id (FK) as distinct first-class ids."""
+
+    @pytest.mark.asyncio
+    async def test_distinct_ids_flow_independently(self):
+        server = MCPServer()
+
+        result = await server.mcp.call_tool(
+            "create_mind",
+            {
+                "mind_id": "mind_abc",
+                "entity_id": "entity_xyz",
+                "config": {"traits": ["curious"]},
+            },
+        )
+        response = parse_response(result)
+
+        assert response["status"] == "created"
+        # Response carries both ids, kept distinct
+        assert response["mind_id"] == "mind_abc"
+        assert response["entity_id"] == "entity_xyz"
+        # Registry keyed by the mind PK, never the entity FK
+        assert "mind_abc" in server.minds
+        assert "entity_xyz" not in server.minds
+        # Stored Mind keeps both fields, distinct
+        mind = server.minds["mind_abc"]
+        assert mind.mind_id == "mind_abc"
+        assert mind.entity_id == "entity_xyz"
+        # Memory collection keyed by the mind PK
+        assert mind.memory_store.collection.name == "mind_mind_abc"

--- a/mind/tests/unit/test_mcp_server.py
+++ b/mind/tests/unit/test_mcp_server.py
@@ -526,8 +526,8 @@ class TestCreateMindDecouplesIds:
 
 
 class TestDecideActionEntityIdMismatch:
-    """decide_action warns (does not reject) when the observation entity_id (FK)
-    diverges from the routed mind entity_id, so misrouting is diagnosable (NPC-795)."""
+    """decide_action rejects (after logging both ids) when the observation entity_id
+    (FK) diverges from the routed mind entity_id - misrouting is a boundary bug (NPC-795)."""
 
     @staticmethod
     async def _run_decide(server, observation):

--- a/mind/tests/unit/test_mcp_server.py
+++ b/mind/tests/unit/test_mcp_server.py
@@ -564,7 +564,7 @@ class TestDecideActionEntityIdMismatch:
         )
 
     @pytest.mark.asyncio
-    async def test_warns_when_observation_entity_id_differs_from_mind(self, caplog):
+    async def test_rejects_when_observation_entity_id_differs_from_mind(self, caplog):
         import logging
 
         server = MCPServer()
@@ -577,12 +577,13 @@ class TestDecideActionEntityIdMismatch:
             result = await self._run_decide(server, observation)
 
         response = parse_response(result)
-        assert response["status"] == "success"
+        assert response["status"] == "error"
+        assert "entity_id mismatch" in response["error_message"]
 
         mismatch_lines = [
             r.getMessage() for r in caplog.records if "entity_id mismatch" in r.getMessage()
         ]
-        assert mismatch_lines, "expected an entity_id mismatch warning"
+        assert mismatch_lines, "expected an entity_id mismatch warning before the reject"
         assert any("entity_other" in line and "entity_test" in line for line in mismatch_lines)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Makes a mind's **primary key** (`mind_id`) and the **foreign key** to the entity it drives (`entity_id`) two distinct, first-class ids — replacing the prior conflation where one value served as both. (This supersedes the closed rename PR #15, which collapsed them the wrong way.)

Main already keyed `self.minds[mind_id]` and the memory collection (`mind_<mind_id>`) by the PK with `config.entity_id` as the FK — they only *looked* unified because the Godot client sent the entity id for both. The Godot half now mints a distinct `mind_id`; this half makes the server treat the two independently:

- `create_mind(mind_id, entity_id, config)` — `entity_id` promoted to a top-level tool arg so `config` is pure configuration (no id). `Mind.from_config(mind_id, entity_id, config)`; collection stays `mind_<mind_id>` (memory belongs to the mind). Returns both ids.
- `MindConfig` drops `entity_id`; `MindInfoResponse` gains `entity_id` (optional — `cleanup_mind` routes by PK and has no FK to report).
- `decide_action` / `cleanup_mind` / `consolidate_memories` route by `mind_id`; `mind://{mind_id}/…` resources stay PK-keyed.
- **Attribution fix (the real NPC-789 / #14 resolution):** per-NPC thought/bid log lines that the simulation forwards to an NPC's Events tab now tag with **`entity_id`** (the FK), not `mind_id` — which only *matters* now that the two differ. Pure server-routing/lifecycle lines (`decide_action` correlation, create/cleanup) stay on `mind_id`. The cognitive pipeline nodes already attribute via the observation's `entity_id` and were left untouched.

Closes NPC-795 (with the Godot half). Persistence/relink across respawns — which this decouple *enables* — is intentionally **not** built here; tracked as NPC-797 (high priority).

## ⚠️ Breaking — atomic merge required

Pairs with the Godot half **[emergent-npcs/npc-simulation#189](https://github.com/emergent-npcs/npc-simulation/pull/189)**. The server now **rejects** `create_mind` calls that omit the new `entity_id` arg or still nest `entity_id` in `config`, so both must land together before the live MCP server restarts. Wire contract (verified byte-for-byte against the Godot client): `create_mind{mind_id, entity_id, config}`, `decide_action{mind_id, observation, events}`, `cleanup_mind{mind_id}`, `consolidate_memories{mind_id}`.

## Test plan

`pytest tests/unit tests/integration` — run twice, stable: **unit 166/166**, **integration 34 passed / 2 failed**. The 2 failures are the pre-existing OpenRouter `404 No endpoints found for google/gemini-2.0-flash-lite-001` in the live-LLM tests (`test_decide_action`, `test_full_workflow`), unrelated to this change. New coverage: `test_distinct_ids_flow_independently` + `test_create_mind` assert the registry is keyed by the PK, `mind.entity_id` == the FK, the response carries both, the collection is PK-keyed, and a caplog assertion proves the bid-cleanup log line carries the **entity FK**, not the mind PK. `grep "matches entity_id"` → 0 hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Thread 4: Substrate & Minds
