### PR TITLE
Server-side mind persistence: relink, forget, reattach (NPC-797 PR2)

### DIFF
--- a/mind/src/mind/cognitive_architecture/memory/vector_db_memory.py
+++ b/mind/src/mind/cognitive_architecture/memory/vector_db_memory.py
@@ -1,6 +1,7 @@
 """Simple memory store using ChromaDB for vector storage"""
 
 import chromadb
+from chromadb.errors import InvalidCollectionException
 from pydantic import BaseModel
 from sentence_transformers import SentenceTransformer
 
@@ -109,6 +110,31 @@ class VectorDBMemory:
         self.collection = self.client.get_or_create_collection(
             name=collection_name, metadata={"hnsw:space": "cosine"}
         )
+
+    @staticmethod
+    def collection_exists(storage_path: str, collection_name: str) -> bool:
+        """Check whether a persisted collection exists without creating it.
+
+        Opens a PersistentClient at storage_path and probes for the collection via
+        get_collection, which raises InvalidCollectionException when absent. Unlike
+        the constructor (which uses get_or_create_collection), this is strictly
+        read-only: it never creates the collection as a side effect, so it's safe
+        for relink to decide whether retained memory survived a release.
+
+        Args:
+            storage_path: Directory path for persistent storage
+            collection_name: Name of the ChromaDB collection to probe
+
+        Returns:
+            True if the collection exists, False otherwise
+        """
+        settings = chromadb.Settings(anonymized_telemetry=False, allow_reset=True)
+        client = chromadb.PersistentClient(path=storage_path, settings=settings)
+        try:
+            client.get_collection(name=collection_name)
+            return True
+        except InvalidCollectionException:
+            return False
 
     def add_memory(
         self,

--- a/mind/src/mind/cognitive_architecture/memory/vector_db_memory.py
+++ b/mind/src/mind/cognitive_architecture/memory/vector_db_memory.py
@@ -153,7 +153,16 @@ class VectorDBMemory:
         .clear(), this loads no SentenceTransformer encoder and never calls
         get_or_create_collection (which would recreate the very collection we're
         about to delete). Use this for the non-resident forget path, where no live
-        store exists. No-op when the path was never persisted.
+        store exists.
+
+        Idempotent (delete-if-exists): safe to call whether or not the path or the
+        collection exists. A never-persisted path is a no-op, and an absent
+        collection is a no-op too - ChromaDB's delete_collection raises on a missing
+        collection rather than no-op'ing, so we gate the delete behind a get probe.
+        That gate is also version-robust: the pinned ChromaDB raises a bare
+        ValueError ("Collection X does not exist.") from delete_collection, while
+        get_collection raises InvalidCollectionException - so probing first avoids
+        coupling to whichever exception delete_collection happens to throw.
 
         Args:
             storage_path: Directory path for persistent storage
@@ -164,6 +173,10 @@ class VectorDBMemory:
 
         settings = chromadb.Settings(anonymized_telemetry=False, allow_reset=True)
         client = chromadb.PersistentClient(path=storage_path, settings=settings)
+        try:
+            client.get_collection(name=collection_name)
+        except InvalidCollectionException:
+            return
         client.delete_collection(collection_name)
 
     def add_memory(

--- a/mind/src/mind/cognitive_architecture/memory/vector_db_memory.py
+++ b/mind/src/mind/cognitive_architecture/memory/vector_db_memory.py
@@ -1,5 +1,7 @@
 """Simple memory store using ChromaDB for vector storage"""
 
+import os
+
 import chromadb
 from chromadb.errors import InvalidCollectionException
 from pydantic import BaseModel
@@ -128,6 +130,12 @@ class VectorDBMemory:
         Returns:
             True if the collection exists, False otherwise
         """
+        # PersistentClient(path=...) creates the directory if it's absent, so probing
+        # a never-persisted path would leave an empty DB dir on disk. Short-circuit
+        # before constructing the client to keep this probe truly read-only.
+        if not storage_path or not os.path.exists(storage_path):
+            return False
+
         settings = chromadb.Settings(anonymized_telemetry=False, allow_reset=True)
         client = chromadb.PersistentClient(path=storage_path, settings=settings)
         try:
@@ -135,6 +143,28 @@ class VectorDBMemory:
             return True
         except InvalidCollectionException:
             return False
+
+    @staticmethod
+    def delete_collection(storage_path: str, collection_name: str) -> None:
+        """Delete a persisted collection without instantiating a full store.
+
+        Mirrors collection_exists: opens a bare PersistentClient and deletes the
+        named collection directly. Unlike constructing VectorDBMemory(...) to call
+        .clear(), this loads no SentenceTransformer encoder and never calls
+        get_or_create_collection (which would recreate the very collection we're
+        about to delete). Use this for the non-resident forget path, where no live
+        store exists. No-op when the path was never persisted.
+
+        Args:
+            storage_path: Directory path for persistent storage
+            collection_name: Name of the ChromaDB collection to delete
+        """
+        if not storage_path or not os.path.exists(storage_path):
+            return
+
+        settings = chromadb.Settings(anonymized_telemetry=False, allow_reset=True)
+        client = chromadb.PersistentClient(path=storage_path, settings=settings)
+        client.delete_collection(collection_name)
 
     def add_memory(
         self,

--- a/mind/src/mind/interfaces/mcp/mind.py
+++ b/mind/src/mind/interfaces/mcp/mind.py
@@ -5,11 +5,11 @@ from typing import Self
 
 from mind.apis.langchain_llm import get_llm
 from mind.cognitive_architecture.memory.vector_db_memory import VectorDBMemory
-from mind.cognitive_architecture.observations import ConversationMessage, MindEvent, MindEventType
 from mind.cognitive_architecture.nodes.cognitive_update.models import NewMemory, WorkingMemory
+from mind.cognitive_architecture.observations import ConversationMessage, MindEvent, MindEventType
 from mind.cognitive_architecture.pipeline import CognitivePipeline
-from mind.logging_config import get_logger
 from mind.interfaces.mcp.models import MindConfig
+from mind.logging_config import get_logger
 
 logger = get_logger()
 

--- a/mind/src/mind/interfaces/mcp/mind.py
+++ b/mind/src/mind/interfaces/mcp/mind.py
@@ -83,6 +83,54 @@ class Mind:
             working_memory=working_memory,
         )
 
+    @classmethod
+    def reattach(cls, mind_id: str, entity_id: str, config: MindConfig) -> Self:
+        """Re-attach a Mind to its retained memory collection.
+
+        Identical to from_config except it does NOT seed
+        config.initial_long_term_memories. The collection already exists (it was
+        retained when the mind was released, not deleted), and VectorDBMemory uses
+        get_or_create_collection, so this transparently reopens it. Skipping the
+        seed loop is what keeps re-attaching idempotent - re-seeding here would
+        duplicate the original seeds on every relink.
+
+        Args:
+            mind_id: The mind's own identifier (PK) - keys the retained collection
+            entity_id: The simulation entity this mind now drives (FK). May differ
+                from the entity the mind drove before release; the relink rebinds it.
+            config: MindConfig with traits, LLM, memory, and personality settings.
+                initial_long_term_memories is intentionally ignored here.
+
+        Returns:
+            Initialized Mind instance bound to the existing collection
+        """
+        # Initialize LLM from config
+        llm = get_llm(config.llm_model)
+
+        # Reopen the retained collection keyed by the mind PK (no seeding)
+        memory_store = VectorDBMemory(
+            collection_name=f"mind_{mind_id}",
+            embedding_model=config.embedding_model,
+            storage_path=config.memory_storage_path,
+        )
+
+        # Initialize pipeline
+        pipeline = CognitivePipeline(llm=llm, memory_store=memory_store)
+
+        # Initialize working memory
+        working_memory = config.initial_working_memory or WorkingMemory()
+
+        # Create Mind instance
+        return cls(
+            mind_id=mind_id,
+            entity_id=entity_id,
+            traits=config.traits,
+            personality_dimensions=config.personality_dimensions,
+            pipeline=pipeline,
+            memory_store=memory_store,
+            working_memory=working_memory,
+        )
+
     def update_conversations(self, conversations: list) -> None:
         """Aggregate conversation updates into full history
 

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -1,21 +1,20 @@
 """MCP server for mind management"""
 
 import json
-import logging
 import uuid
 
 from fastmcp import Context, FastMCP
 from pydantic import ValidationError
 
 from mind.cognitive_architecture.actions import ActionType
+from mind.cognitive_architecture.memory.vector_db_memory import VectorDBMemory
+from mind.cognitive_architecture.nodes.memory_consolidation.node import MemoryConsolidationNode
 from mind.cognitive_architecture.observations import (
     ConversationObservation,
     MindEvent,
     MindEventType,
     Observation,
 )
-from mind.cognitive_architecture.memory.vector_db_memory import VectorDBMemory
-from mind.cognitive_architecture.nodes.memory_consolidation.node import MemoryConsolidationNode
 from mind.cognitive_architecture.state import PipelineState
 from mind.logging_config import get_logger
 
@@ -371,7 +370,7 @@ class MCPServer:
         ) -> MindInfoResponse:
             """Re-bind a mind to a (possibly new) driven entity, rehydrating if needed.
 
-            Two paths:
+            Three paths:
             - Mind still resident in self.minds: rebind its entity_id (FK) in place
               and report "relinked". No collection work - the live mind already holds
               its memory.
@@ -431,12 +430,9 @@ class MCPServer:
                 mind.memory_store.client.delete_collection(collection_name)
                 del self.minds[mind_id]
             elif VectorDBMemory.collection_exists(config.memory_storage_path, collection_name):
-                store = VectorDBMemory(
-                    collection_name=collection_name,
-                    embedding_model=config.embedding_model,
-                    storage_path=config.memory_storage_path,
-                )
-                store.client.delete_collection(collection_name)
+                # Non-resident: delete via a bare client (no encoder load, no
+                # get_or_create_collection that would recreate the collection first).
+                VectorDBMemory.delete_collection(config.memory_storage_path, collection_name)
 
             return MindInfoResponse(status="forgotten", mind_id=mind_id, entity_id=entity_id)
 

--- a/mind/src/mind/interfaces/mcp/server.py
+++ b/mind/src/mind/interfaces/mcp/server.py
@@ -14,6 +14,7 @@ from mind.cognitive_architecture.observations import (
     MindEventType,
     Observation,
 )
+from mind.cognitive_architecture.memory.vector_db_memory import VectorDBMemory
 from mind.cognitive_architecture.nodes.memory_consolidation.node import MemoryConsolidationNode
 from mind.cognitive_architecture.state import PipelineState
 from mind.logging_config import get_logger
@@ -340,20 +341,104 @@ class MCPServer:
             mind_id: str,
             ctx: Context = None,
         ) -> MindInfoResponse:
-            """Gracefully cleanup and remove a mind
+            """Release a mind from memory while RETAINING its persisted collection.
+
+            This drops the in-memory Mind instance (frees its pipeline/working state)
+            but deliberately does NOT delete the ChromaDB collection. The retained
+            collection is what lets a later relink_mind re-attach via Mind.reattach
+            and recover the mind's long-term memory. To actually erase memory, use
+            forget_mind. The "released" status reflects this retain-on-release
+            contract (the mind is released, its memory persists).
 
             Args:
-                mind_id: Mind to remove
+                mind_id: Mind to release
             """
             # The mind is still registered here, so its entity_id (FK) is available;
-            # surface it in the response so cleanup is symmetric with create_mind.
+            # surface it in the response so release is symmetric with create_mind.
             # (The Godot client ignores this optional field, so this is non-breaking.)
             entity_id = None
             if mind_id in self.minds:
                 entity_id = self.minds[mind_id].entity_id
                 del self.minds[mind_id]
 
-            return MindInfoResponse(status="removed", mind_id=mind_id, entity_id=entity_id)
+            return MindInfoResponse(status="released", mind_id=mind_id, entity_id=entity_id)
+
+        @self.mcp.tool()
+        async def relink_mind(
+            mind_id: str,
+            entity_id: str,
+            ctx: Context = None,
+        ) -> MindInfoResponse:
+            """Re-bind a mind to a (possibly new) driven entity, rehydrating if needed.
+
+            Two paths:
+            - Mind still resident in self.minds: rebind its entity_id (FK) in place
+              and report "relinked". No collection work - the live mind already holds
+              its memory.
+            - Mind released but its collection retained (cleanup_mind kept it): if
+              collection_exists, rehydrate via Mind.reattach (no re-seeding), register
+              it under the PK, and report "relinked".
+            - Neither resident nor a retained collection: report "not_found".
+
+            Args:
+                mind_id: The mind's own identifier (PK) - keys self.minds and the
+                    retained collection.
+                entity_id: The simulation entity this mind should now drive (FK).
+            """
+            # Resident: rebind the FK in place. mind_id (PK) is the stable identity;
+            # the driven entity can change across relinks.
+            if mind_id in self.minds:
+                self.minds[mind_id].entity_id = entity_id
+                return MindInfoResponse(status="relinked", mind_id=mind_id, entity_id=entity_id)
+
+            # Not resident: rehydrate from a retained collection if one survives.
+            # reattach uses the default cognitive config (storage_path/embedding);
+            # initial_long_term_memories is irrelevant since reattach never seeds.
+            config = MindConfig(traits=[])
+            if VectorDBMemory.collection_exists(config.memory_storage_path, f"mind_{mind_id}"):
+                mind = Mind.reattach(mind_id, entity_id, config)
+                self.minds[mind_id] = mind
+                return MindInfoResponse(status="relinked", mind_id=mind_id, entity_id=entity_id)
+
+            return MindInfoResponse(status="not_found", mind_id=mind_id, entity_id=entity_id)
+
+        @self.mcp.tool()
+        async def forget_mind(
+            mind_id: str,
+            ctx: Context = None,
+        ) -> MindInfoResponse:
+            """Permanently erase a mind's memory and drop it from the registry.
+
+            The destructive counterpart to cleanup_mind: it deletes the persisted
+            ChromaDB collection outright (not VectorDBMemory.clear, which would
+            recreate an empty collection), so collection_exists is False afterward
+            and a subsequent relink_mind reports "not_found". Also drops the
+            in-memory Mind if still resident.
+
+            Args:
+                mind_id: Mind to forget
+            """
+            entity_id = None
+            config = MindConfig(traits=[])
+            collection_name = f"mind_{mind_id}"
+
+            # Resolve the FK (if resident) and drop the in-memory instance. The live
+            # store's client is reused for the delete when resident; otherwise open a
+            # client just to delete the retained collection.
+            if mind_id in self.minds:
+                mind = self.minds[mind_id]
+                entity_id = mind.entity_id
+                mind.memory_store.client.delete_collection(collection_name)
+                del self.minds[mind_id]
+            elif VectorDBMemory.collection_exists(config.memory_storage_path, collection_name):
+                store = VectorDBMemory(
+                    collection_name=collection_name,
+                    embedding_model=config.embedding_model,
+                    storage_path=config.memory_storage_path,
+                )
+                store.client.delete_collection(collection_name)
+
+            return MindInfoResponse(status="forgotten", mind_id=mind_id, entity_id=entity_id)
 
         # === Resources ===
 

--- a/mind/tests/integration/test_mcp_server.py
+++ b/mind/tests/integration/test_mcp_server.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from mind.cognitive_architecture.nodes.cognitive_update.models import WorkingMemory
 from mind.cognitive_architecture.observations import (
     EntityData,
     NeedsObservation,
@@ -11,7 +12,6 @@ from mind.cognitive_architecture.observations import (
     StatusObservation,
     VisionObservation,
 )
-from mind.cognitive_architecture.nodes.cognitive_update.models import WorkingMemory
 from mind.interfaces.mcp.models import MindConfig
 from mind.interfaces.mcp.server import MCPServer
 
@@ -245,7 +245,8 @@ async def test_cleanup_mind(mcp_server, test_mind_config):
     # Parse response from TextContent list
     response = json.loads(result[0].text)
 
-    assert response["status"] == "removed"
+    # cleanup_mind releases the mind but RETAINS its collection (retain-on-release).
+    assert response["status"] == "released"
     assert response["mind_id"] == "test_mind_001"
     assert "test_mind_001" not in mcp_server.minds
 
@@ -287,10 +288,10 @@ async def test_full_workflow(mcp_server, test_mind_config, test_observation):
         assert consolidate_response["status"] == "success"
         assert consolidate_response["consolidated_count"] == memory_count
 
-    # Step 5: Cleanup
+    # Step 5: Cleanup (releases the mind; collection retained per retain-on-release)
     result = await mcp_server.mcp.call_tool("cleanup_mind", {"mind_id": "test_mind_001"})
     cleanup_response = json.loads(result[0].text)
-    assert cleanup_response["status"] == "removed"
+    assert cleanup_response["status"] == "released"
 
 
 if __name__ == "__main__":

--- a/mind/tests/unit/test_mcp_server.py
+++ b/mind/tests/unit/test_mcp_server.py
@@ -1,10 +1,9 @@
 """Unit tests for MCP server"""
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
-from langchain_core.messages import AIMessage
 
 from mind.interfaces.mcp.server import MCPServer
 
@@ -283,7 +282,7 @@ class TestMCPServerErrorHandling:
         import logging
 
         from mind.cognitive_architecture.actions import Action, ActionType
-        from mind.cognitive_architecture.observations import MindEvent, MindEventType
+        from mind.cognitive_architecture.observations import MindEventType
         from mind.cognitive_architecture.state import PipelineState
 
         server = MCPServer()
@@ -457,6 +456,7 @@ class TestMindConfigValidation:
 
     def test_rejects_value_above_one(self):
         from pydantic import ValidationError
+
         from mind.interfaces.mcp.models import MindConfig
         with pytest.raises(ValidationError):
             MindConfig(
@@ -466,6 +466,7 @@ class TestMindConfigValidation:
 
     def test_rejects_negative_value(self):
         from pydantic import ValidationError
+
         from mind.interfaces.mcp.models import MindConfig
         with pytest.raises(ValidationError):
             MindConfig(
@@ -789,3 +790,52 @@ class TestMindPersistenceLifecycle:
         )
         assert relink["status"] == "relinked"
         assert server2.minds["mind_f"].memory_store.collection.count() == count_before
+
+    def test_collection_exists_is_false_and_creates_no_dir_for_missing_path(self):
+        """collection_exists must be a pure read: a never-persisted path returns False
+        and is NOT created on disk as a side effect (PersistentClient otherwise mkdir's
+        the path). Regression for the empty-DB-dir leak (PR #17 review)."""
+        import os
+
+        from mind.cognitive_architecture.memory.vector_db_memory import VectorDBMemory
+
+        missing_path = os.path.join(os.getcwd(), "never_persisted_db")
+        assert not os.path.exists(missing_path)
+
+        assert VectorDBMemory.collection_exists(missing_path, "mind_ghost") is False
+
+        # The probe must not have created the directory.
+        assert not os.path.exists(missing_path)
+
+    @pytest.mark.asyncio
+    async def test_forget_non_resident_deletes_collection_without_loading_encoder(self):
+        """Forgetting a non-resident retained collection must delete it via a bare
+        client - no SentenceTransformer load, no get_or_create that would recreate the
+        collection before deleting it. Regression for the heavy-construct forget path
+        (PR #17 review)."""
+        from mind.cognitive_architecture.memory.vector_db_memory import VectorDBMemory
+        from mind.interfaces.mcp.models import MindConfig
+
+        server = MCPServer()
+        storage_path = MindConfig(traits=[]).memory_storage_path
+
+        # Create + release so the collection is retained on disk but no live Mind holds it.
+        await self._create_mind(server, "mind_g", "entity_g")
+        server.minds["mind_g"].memory_store.add_memory(content="z", importance=5.0)
+        await server.mcp.call_tool("cleanup_mind", {"mind_id": "mind_g"})
+        assert "mind_g" not in server.minds
+        assert VectorDBMemory.collection_exists(storage_path, "mind_mind_g") is True
+
+        # Patch the encoder constructor on the module VectorDBMemory uses; the
+        # non-resident forget path must never instantiate it.
+        with patch(
+            "mind.cognitive_architecture.memory.vector_db_memory.SentenceTransformer"
+        ) as encoder_ctor:
+            forget = parse_response(
+                await server.mcp.call_tool("forget_mind", {"mind_id": "mind_g"})
+            )
+
+        assert forget["status"] == "forgotten"
+        encoder_ctor.assert_not_called()
+        # Collection is gone (not recreated as an empty shell).
+        assert VectorDBMemory.collection_exists(storage_path, "mind_mind_g") is False

--- a/mind/tests/unit/test_mcp_server.py
+++ b/mind/tests/unit/test_mcp_server.py
@@ -606,3 +606,186 @@ class TestDecideActionEntityIdMismatch:
             r.getMessage() for r in caplog.records if "entity_id mismatch" in r.getMessage()
         ]
         assert not mismatch_lines, "no mismatch warning expected when ids agree"
+
+
+class TestMindPersistenceLifecycle:
+    """Server-side mind persistence: release retains memory, relink rebinds/rehydrates,
+    forget erases (NPC-797).
+
+    Each test runs in an isolated tmp dir so the default MindConfig
+    memory_storage_path ("./chroma_db") - the same path create, relink, and forget
+    all use - resolves under a hermetic per-test directory. The autouse fixture also
+    clears ChromaDB's process-global client cache: PersistentClient caches its
+    system per-process regardless of the resolved path, so without the reset a later
+    test's "./chroma_db" would alias the first test's on-disk store and counts would
+    bleed across tests (a test-isolation artifact, not server behavior - in
+    production the server is one long-lived process keyed by distinct mind_ids).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_chroma(self, monkeypatch, tmp_path):
+        from chromadb.api.client import SharedSystemClient
+
+        SharedSystemClient.clear_system_cache()
+        monkeypatch.chdir(tmp_path)
+        yield
+        SharedSystemClient.clear_system_cache()
+
+    @staticmethod
+    async def _create_mind(server, mind_id, entity_id, initial_memories=None):
+        config = {"traits": [], "initial_long_term_memories": initial_memories or []}
+        return await server.mcp.call_tool(
+            "create_mind",
+            {"mind_id": mind_id, "entity_id": entity_id, "config": config},
+        )
+
+    @pytest.mark.asyncio
+    async def test_relink_resident_mind_rebinds_fk_in_place(self):
+        """A still-resident mind keeps its collection and just gets a new entity FK."""
+        server = MCPServer()
+
+        await self._create_mind(server, "mind_a", "entity_old")
+        mind = server.minds["mind_a"]
+        mind.memory_store.add_memory(content="a remembered fact", importance=5.0)
+        count_before = mind.memory_store.collection.count()
+        assert count_before == 1
+
+        result = await server.mcp.call_tool(
+            "relink_mind", {"mind_id": "mind_a", "entity_id": "entity_new"}
+        )
+        response = parse_response(result)
+
+        assert response["status"] == "relinked"
+        # Same live instance, FK rebound in place, memory untouched.
+        assert server.minds["mind_a"] is mind
+        assert mind.entity_id == "entity_new"
+        assert mind.memory_store.collection.count() == count_before
+
+    @pytest.mark.asyncio
+    async def test_release_retains_collection_then_relink_rehydrates_with_new_fk(self):
+        """cleanup_mind retains the collection; relink rehydrates it with a new FK
+        and the memory count is unchanged."""
+        server = MCPServer()
+
+        await self._create_mind(server, "mind_b", "entity_old")
+        server.minds["mind_b"].memory_store.add_memory(content="retained memory", importance=5.0)
+        count_before = server.minds["mind_b"].memory_store.collection.count()
+        assert count_before == 1
+
+        release = parse_response(
+            await server.mcp.call_tool("cleanup_mind", {"mind_id": "mind_b"})
+        )
+        assert release["status"] == "released"
+        assert "mind_b" not in server.minds
+
+        relink = parse_response(
+            await server.mcp.call_tool(
+                "relink_mind", {"mind_id": "mind_b", "entity_id": "entity_new"}
+            )
+        )
+        assert relink["status"] == "relinked"
+
+        # Rehydrated instance: collection intact, FK is the new one.
+        rehydrated = server.minds["mind_b"]
+        assert rehydrated.entity_id == "entity_new"
+        assert rehydrated.memory_store.collection.count() == count_before
+
+    @pytest.mark.asyncio
+    async def test_relink_does_not_reseed_initial_memories(self):
+        """reattach skips the seed loop, so relinking does not double the seeds."""
+        server = MCPServer()
+
+        await self._create_mind(
+            server, "mind_c", "entity_c", initial_memories=["seed one", "seed two"]
+        )
+        seed_count = server.minds["mind_c"].memory_store.collection.count()
+        assert seed_count == 2
+
+        await server.mcp.call_tool("cleanup_mind", {"mind_id": "mind_c"})
+        await server.mcp.call_tool(
+            "relink_mind", {"mind_id": "mind_c", "entity_id": "entity_c"}
+        )
+
+        # If reattach re-seeded, this would be 4. It must stay 2.
+        assert server.minds["mind_c"].memory_store.collection.count() == seed_count
+
+    @pytest.mark.asyncio
+    async def test_cleanup_retains_but_forget_deletes_collection(self):
+        """collection_exists is True after release, False after forget."""
+        from mind.cognitive_architecture.memory.vector_db_memory import VectorDBMemory
+        from mind.interfaces.mcp.models import MindConfig
+
+        server = MCPServer()
+        storage_path = MindConfig(traits=[]).memory_storage_path
+
+        await self._create_mind(server, "mind_d", "entity_d")
+        server.minds["mind_d"].memory_store.add_memory(content="x", importance=5.0)
+
+        await server.mcp.call_tool("cleanup_mind", {"mind_id": "mind_d"})
+        assert VectorDBMemory.collection_exists(storage_path, "mind_mind_d") is True
+
+        forget = parse_response(
+            await server.mcp.call_tool("forget_mind", {"mind_id": "mind_d"})
+        )
+        assert forget["status"] == "forgotten"
+        assert VectorDBMemory.collection_exists(storage_path, "mind_mind_d") is False
+
+        # A relink after forget finds nothing.
+        relink = parse_response(
+            await server.mcp.call_tool(
+                "relink_mind", {"mind_id": "mind_d", "entity_id": "entity_d"}
+            )
+        )
+        assert relink["status"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_forget_resident_mind_drops_instance_and_collection(self):
+        """forget_mind on a resident mind drops it from the registry and deletes its
+        collection (no recreated empty shell)."""
+        from mind.cognitive_architecture.memory.vector_db_memory import VectorDBMemory
+        from mind.interfaces.mcp.models import MindConfig
+
+        server = MCPServer()
+        storage_path = MindConfig(traits=[]).memory_storage_path
+
+        await self._create_mind(server, "mind_e", "entity_e")
+        server.minds["mind_e"].memory_store.add_memory(content="y", importance=5.0)
+
+        forget = parse_response(
+            await server.mcp.call_tool("forget_mind", {"mind_id": "mind_e"})
+        )
+        assert forget["status"] == "forgotten"
+        assert forget["entity_id"] == "entity_e"
+        assert "mind_e" not in server.minds
+        assert VectorDBMemory.collection_exists(storage_path, "mind_mind_e") is False
+
+    @pytest.mark.asyncio
+    async def test_restart_reattach_recovers_memory_across_server_instances(self):
+        """Simulate a server restart: create + memory on one instance, drop it, then a
+        fresh MCPServer relinks the same mind_id and the memory survives.
+
+        Note: clearing ChromaDB's client cache between server instances (the autouse
+        fixture does this at setup/teardown, not mid-test) is unnecessary here -
+        within one process the cached client correctly reopens the on-disk store,
+        which is exactly the restart-recovery path under test.
+        """
+        server1 = MCPServer()
+        await self._create_mind(server1, "mind_f", "entity_f")
+        server1.minds["mind_f"].memory_store.add_memory(
+            content="survives restart", importance=5.0
+        )
+        count_before = server1.minds["mind_f"].memory_store.collection.count()
+        assert count_before == 1
+
+        # Drop the whole server instance (collection is persisted on disk).
+        del server1
+
+        server2 = MCPServer()
+        assert "mind_f" not in server2.minds
+        relink = parse_response(
+            await server2.mcp.call_tool(
+                "relink_mind", {"mind_id": "mind_f", "entity_id": "entity_f"}
+            )
+        )
+        assert relink["status"] == "relinked"
+        assert server2.minds["mind_f"].memory_store.collection.count() == count_before

--- a/mind/tests/unit/test_vector_db_memory.py
+++ b/mind/tests/unit/test_vector_db_memory.py
@@ -211,3 +211,39 @@ class TestVectorDBMemory:
         assert "sword" in results[0].content.lower()
         assert results[0].importance < results[1].importance
 
+
+class TestDeleteCollection:
+    """delete_collection is idempotent (delete-if-exists), with no encoder load."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_chroma(self, monkeypatch, tmp_path):
+        """Isolate ChromaDB's process-global client cache and CWD per test, so a
+        PersistentClient opened here can't alias another test's on-disk store."""
+        from chromadb.api.client import SharedSystemClient
+
+        SharedSystemClient.clear_system_cache()
+        monkeypatch.chdir(tmp_path)
+        yield
+        SharedSystemClient.clear_system_cache()
+
+    def test_delete_absent_collection_on_existing_path_does_not_raise(self):
+        """Deleting a missing collection from an existing storage path is a silent
+        no-op, not a raise (ChromaDB's delete_collection raises on absent). The path
+        must already exist (so the missing-path early-return doesn't mask the case),
+        but the named collection must not - exercising the delete-if-exists guard."""
+        import os
+
+        storage_path = os.path.join(os.getcwd(), "chroma_persist")
+
+        # Persist a DIFFERENT collection so the storage path exists on disk while the
+        # target collection does not - isolating the absent-collection branch.
+        VectorDBMemory(collection_name="present_one", storage_path=storage_path)
+        assert os.path.exists(storage_path)
+        assert VectorDBMemory.collection_exists(storage_path, "never_made") is False
+
+        # Must not raise.
+        VectorDBMemory.delete_collection(storage_path, "never_made")
+
+        # Still absent (delete-if-exists left the world unchanged).
+        assert VectorDBMemory.collection_exists(storage_path, "never_made") is False
+


### PR DESCRIPTION
## Summary

PR2 of NPC-797 — **server side** of mind persistence. NPC-795 (merged) keyed minds and their ChromaDB memory by `mind_id`; `cleanup_mind` already retains the collection on release. This PR adds the ops that let a retained memory be re-bound, recovered after restart, or permanently erased.

- `mind.py`: `Mind.reattach(mind_id, entity_id, config)` — identical to `from_config` but **omits the `initial_long_term_memories` seed loop**, so re-attaching to a retained collection never duplicates seeds. Relies on `VectorDBMemory`'s `get_or_create_collection` to transparently reopen.
- `vector_db_memory.py`: `collection_exists(storage_path, collection_name) -> bool` — read-only `get_collection` probe (catches `InvalidCollectionException`, never creates).
- `server.py`: MCP tools `relink_mind(mind_id, entity_id)` (resident → in-place FK rebind; released-but-retained → rehydrate via `reattach`; else `not_found`) and `forget_mind(mind_id)` (true `delete_collection`, drops resident instance). `cleanup_mind` status `removed` → `released` and docstring states the retain-on-release contract.

`models.py` unchanged — `MindInfoResponse` already carries `status`/`mind_id`/`entity_id`; only the status string values are new.

The Godot side is **PR1** (emergent-npcs/npc-simulation#220, identity persistence, server-independent). The Godot↔server **wire is PR3**.

## Decisions

- **`forget_mind` uses `client.delete_collection`, not `VectorDBMemory.clear()`** — `clear()` deletes *and recreates* an empty collection, which would leave `collection_exists` True after forget and break the retain/forget distinction.
- **Test isolation:** `chromadb.PersistentClient` caches its system per-process regardless of path, so per-test tmp dirs aliased one store and counts bled across tests. An autouse fixture calls `SharedSystemClient.clear_system_cache()` + `chdir(tmp_path)` to make each test hermetic. Test artifact only — production is one long-lived process keyed by distinct mind_ids.

## ⚠️ Open question for PR3 (needs a decision before the wire lands)

`relink_mind`/`forget_mind` build a default `MindConfig(traits=[])` to source `memory_storage_path`/`embedding_model`. **If a mind was created with a non-default `memory_storage_path`, a relink after it's no longer resident looks in the wrong directory and returns `not_found`.** Within this PR's scope (defaults match) it's fine, but PR3/production needs either a server-level storage-path constant (not per-create config) or per-mind persisted config. Flagging now so it's decided before PR3.

## Test plan

- [x] `TestMindPersistenceLifecycle` (6 new): resident FK rebind; release-retains then relink-rehydrates-with-new-FK; no-reseed-on-relink; retain-vs-forget (`collection_exists` True after release / False after forget / relink to not_found); forget-resident; cross-instance restart recovery.
- [x] Touched-file tests: **31 passed** x2. Full unit suite: **174 passed** x2 (earlier 2nd-run flakiness was the cache leak, now fixed).
- [x] No Godot changes (N/A static analysis / Godot tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Thread 4: Substrate
